### PR TITLE
Faster transfer to root

### DIFF
--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -1141,8 +1141,8 @@ AnimationClip.prototype.setInterpolationType = function (type) {
 // *===============================================================================================================
 var AnimationEvent = function AnimationEvent(name, time, fnCallback, context, parameter) {
     this.name = name;
-    this.triggerTime = time;
-    this.fnCallback = fnCallback; 
+    this.triggerTime = time; 
+    this.fnCallback = fnCallback;
     this.context = context || this;
     this.parameter = parameter;
 

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -1139,11 +1139,11 @@ AnimationClip.prototype.setInterpolationType = function (type) {
 // *===============================================================================================================
 // * class AnimationEvent:
 // *===============================================================================================================
-var AnimationEvent = function AnimationEvent(name, time, fnCallback, context, parameter) {
+var AnimationEvent = function AnimationEvent(name, time, fnCallback, context, parameter) { 
     this.name = name; 
     this.triggerTime = time;
     this.fnCallback = fnCallback;
-    this.context = context || this;
+    this.context = context || this; 
     this.parameter = parameter;
 
     this.triggered = false;

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -1221,7 +1221,7 @@ var AnimationSession = function AnimationSession(playable, targets) {
         if(self.fadeDir) {
             self.fadeTime +=  dt;// (self.bySpeed * dt);
             if(self.fadeTime >= self.fadeEndTime) {
-                if(self.fadeDir === 1) { // fadein completed 
+                if(self.fadeDir === 1) { // fadein completed  
                     self.fadeDir = 0;
                     self.fadeBegTime = -1;
                     self.fadeEndTime = -1;

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -166,7 +166,7 @@ var AnimationTarget = function AnimationTarget(targetNode, targetPath, targetPro
     this.targetProp = targetProp;
 };
 
-// blend related
+// blend related 
 AnimationTarget.prototype.toString = function(){
     var str = "";
     if(this.targetNode)
@@ -1100,7 +1100,7 @@ AnimationClip.prototype.transferToRoot = function (root) {
     }
 };
 
-// blend related
+// blend related 
 AnimationClip.prototype.updateCurveNameFromTarget = function () {
     var curveNames = Object.keys(this.animCurves);
     for (var i = 0; i < curveNames.length; i++) { // for each curve in clip
@@ -1199,15 +1199,15 @@ var AnimationSession = function AnimationSession(playable, targets) {
         self.curTime += (self.bySpeed * dt);
         self.accTime += (self.bySpeed * dt);
 
-        if (!self.isPlaying ||// not playing 
+        if (!self.isPlaying ||// not playing
             (!self.loop && (self.curTime < self.begTime || self.curTime > self.endTime))){ // not in range 
             self.invokeByTime(self.curTime);
             self.stop();
             self.invokeByName("stop");
             return;
         }
-
-        // round time to duration
+        
+        //round time to duration
         var duration = self.endTime - self.begTime;
         if (self.curTime > self.endTime) { // loop start
             self.invokeByTime(self.curTime);
@@ -1226,7 +1226,7 @@ var AnimationSession = function AnimationSession(playable, targets) {
                     self.fadeBegTime = -1;
                     self.fadeEndTime = -1;
                     self.fadeTime = -1; 
-                } else if (self.fadeDir === -1) { // fadeout completed 
+                } else if (self.fadeDir === -1) { // fadeout completed
                     self.stop();
                     return;
                 }
@@ -1250,17 +1250,17 @@ AnimationSession.prototype.setBlend = function(blendValue, weight, curveName){
         return;
     }
 
-    // blendable is just a single DOF=================================
+    //blendable is just a single DOF=================================
     var keyType;
-    if(typeof blendValue === "number")// 1 instanceof Number is false, don't know why
+    if(typeof blendValue === "number")//1 instanceof Number is false, don't know why
         keyType =  AnimationKeyableType.NUM;
     else if(blendValue instanceof pc.Vec3)
         keyType = AnimationKeyableType.VEC;
     else if(blendValue instanceof pc.Quat)
         keyType = AnimationKeyableType.QUAT;
 
-    if(!curveName || curveName === "" || typeof keyType === "undefined")// has to specify curveName
-        return;
+    if(!curveName || curveName === "" || typeof keyType === "undefined")//has to specify curveName
+        return;  
 
     this.blendWeights[curveName] = weight;
     this.blendables[curveName] = new AnimationKeyable(keyType, 0, blendValue);
@@ -1276,7 +1276,6 @@ AnimationSession.prototype.unsetBlend = function(curveName) {
         delete this.blendWeights[curveName];
     }
 }; 
-
 // events related
 AnimationSession.prototype.on = function (name, time, fnCallback, context, parameter) {
     if (!name || !fnCallback)
@@ -1442,7 +1441,7 @@ AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEn
     if(fadeDir === 0 || fadeTime < fadeBegTime || fadeTime > fadeEndTime) 
         this.updateToTarget(input);
     else {
-        p = (fadeTime - fadeBegTime) / (fadeEndTime - fadeBegTime);
+        var p = (fadeTime - fadeBegTime) / (fadeEndTime - fadeBegTime);
         if (fadeDir === -1)
             p = 1 - p;
         this.blendToTarget(input, p);
@@ -1516,8 +1515,8 @@ AnimationSession.prototype.resume = function () {
     }
 };
 
-AnimationSession.prototype.fadeOut = function (duration) { 
-    this.fadeBegTime = this.curTime; 
+AnimationSession.prototype.fadeOut = function (duration) {  
+    this.fadeBegTime = this.curTime;
     this.fadeTime = this.fadeBegTime;
     this.fadeEndTime = this.fadeBegTime + duration;
     this.fadeDir = -1;
@@ -1600,7 +1599,7 @@ AnimationComponent.prototype.stopClip = function () {
 
 AnimationComponent.prototype.crossFadeToClip = function (name, duration) {
     if (this.animClips[this.curClip] && this.animClips[name]) { 
-        // this.animClips[this.curClip].fadeTo(this.animClips[name], duration); 
+        // this.animClips[this.curClip].fadeTo(this.animClips[name], duration);
         this.animClips[this.curClip].fadeOut(duration);
         this.animClips[name].fadeIn(duration);
         this.curClip = name;
@@ -1613,8 +1612,7 @@ AnimationComponent.prototype.crossFadeToClip = function (name, duration) {
     }
 };
 
-
-// blend related
+// blend related 
 AnimationComponent.prototype.setBlend = function (blendValue, weight, curveName) {
     var curClip = this.getCurrentClip();
     if(curClip && curClip.session)

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -165,8 +165,8 @@ var AnimationTarget = function AnimationTarget(targetNode, targetPath, targetPro
     this.targetPath = targetPath;
     this.targetProp = targetProp;
 };
- 
-// blend related  
+
+// blend related
 AnimationTarget.prototype.toString = function(){
     var str = "";
     if(this.targetNode)
@@ -1099,7 +1099,7 @@ AnimationClip.prototype.transferToRoot = function (root) {
         }
     }
 };
- 
+
 // blend related
 AnimationClip.prototype.updateCurveNameFromTarget = function () {
     var curveNames = Object.keys(this.animCurves);
@@ -1138,9 +1138,9 @@ AnimationClip.prototype.setInterpolationType = function (type) {
 
 // *===============================================================================================================
 // * class AnimationEvent:
-// *=============================================================================================================== 
-var AnimationEvent = function AnimationEvent(name, time, fnCallback, context, parameter) { 
-    this.name = name; 
+// *===============================================================================================================
+var AnimationEvent = function AnimationEvent(name, time, fnCallback, context, parameter) {
+    this.name = name;
     this.triggerTime = time;
     this.fnCallback = fnCallback;
     this.context = context || this;
@@ -1148,10 +1148,10 @@ var AnimationEvent = function AnimationEvent(name, time, fnCallback, context, pa
 
     this.triggered = false;
 };
- 
+
 AnimationEvent.prototype.invoke = function () {
-    if (this.fnCallback) { 
-        this.fnCallback.call(this.context, this.parameter);  
+    if (this.fnCallback) {
+        this.fnCallback.call(this.context, this.parameter);
         this.triggered = true;
     }
 };
@@ -1188,24 +1188,22 @@ var AnimationSession = function AnimationSession(playable, targets) {
         this.animTargets = targets;// collection of AnimationTarget
 
     this.animEvents = [];
- 
     // blend related==========================================================
     this.blendables = {};
     this.blendWeights = {};
 
     // ontimer function for playback
-    var self = this; 
+    var self = this;
     this.onTimer = function (dt) {
         self.curTime += (self.bySpeed * dt);
-        self.accTime += (self.bySpeed * dt); 
+        self.accTime += (self.bySpeed * dt);
         if (!self.isPlaying ||// not playing
-            (!self.loop && (self.curTime < self.begTime || self.curTime > self.endTime))){ // not in range 
+            (!self.loop && (self.curTime < self.begTime || self.curTime > self.endTime))){ // not in range
             self.invokeByTime(self.curTime);
             self.stop();
             self.invokeByName("stop");
             return;
         }
-        
         //round time to duration
         var duration = self.endTime - self.begTime;
         if (self.curTime > self.endTime) { // loop start
@@ -1213,18 +1211,18 @@ var AnimationSession = function AnimationSession(playable, targets) {
             self.curTime -= duration;
             for (var i = 0; i < self.animEvents.length; i ++)
                 self.animEvents[i].triggered = false;
-        } 
-        if (self.curTime < self.begTime) 
+        }
+        if (self.curTime < self.begTime)
             self.curTime += duration;
 
         if(self.fadeDir) {
             self.fadeTime +=  dt;// (self.bySpeed * dt);
             if(self.fadeTime >= self.fadeEndTime) {
-                if(self.fadeDir === 1) { // fadein completed  
+                if(self.fadeDir === 1) { // fadein completed
                     self.fadeDir = 0;
                     self.fadeBegTime = -1;
                     self.fadeEndTime = -1;
-                    self.fadeTime = -1; 
+                    self.fadeTime = -1;
                 } else if (self.fadeDir === -1) { // fadeout completed
                     self.stop();
                     return;
@@ -1234,9 +1232,9 @@ var AnimationSession = function AnimationSession(playable, targets) {
 
         self.showAt(self.curTime, self.fadeDir, self.fadeBegTime, self.fadeEndTime, self.fadeTime);
         self.invokeByTime(self.curTime);
-    }; 
+    };
 };
- 
+
 AnimationSession.app = null;
 
 // blend related==========================================================
@@ -1245,7 +1243,7 @@ AnimationSession.prototype.setBlend = function(blendValue, weight, curveName){
         if(!curveName || curveName === "")
             curveName = "__default__";
         this.blendables[curveName] = blendValue;
-        this.blendWeights[curveName] = weight; 
+        this.blendWeights[curveName] = weight;
         return;
     }
 
@@ -1259,7 +1257,7 @@ AnimationSession.prototype.setBlend = function(blendValue, weight, curveName){
         keyType = AnimationKeyableType.QUAT;
 
     if(!curveName || curveName === "" || typeof keyType === "undefined")//has to specify curveName
-        return;  
+        return;
 
     this.blendWeights[curveName] = weight;
     this.blendables[curveName] = new AnimationKeyable(keyType, 0, blendValue);
@@ -1411,7 +1409,7 @@ AnimationSession.prototype.updateToTarget = function (input) {
     }
 };
 
-AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndTime, fadeTime) { 
+AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndTime, fadeTime) {
     var i, p;
     var input = this.playable.eval(time);
     // blend related==========================================================
@@ -1437,15 +1435,15 @@ AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEn
         input.curveKeyable[cname] = resKey;
     }
 
-    if(fadeDir === 0 || fadeTime < fadeBegTime || fadeTime > fadeEndTime) 
+    if(fadeDir === 0 || fadeTime < fadeBegTime || fadeTime > fadeEndTime)
         this.updateToTarget(input);
     else {
         var p = (fadeTime - fadeBegTime) / (fadeEndTime - fadeBegTime);
         if (fadeDir === -1)
             p = 1 - p;
-        this.blendToTarget(input, p); 
+        this.blendToTarget(input, p);
     }
-};  
+};
 
 AnimationSession.prototype.play = function (playable, animTargets) {
     var i;
@@ -1471,15 +1469,15 @@ AnimationSession.prototype.play = function (playable, animTargets) {
 
     if (!animTargets && typeof playable.getAnimTargets === "function")
         this.animTargets = playable.getAnimTargets();
-    else 
-        this.animTargets = animTargets; 
+    else
+        this.animTargets = animTargets;
 
     // reset events
     for (i = 0; i < this.animEvents.length; i ++)
         this.animEvents[i].triggered = false;
 
     var app = pc.Application.getApplication();
-    app.on('update', this.onTimer); 
+    app.on('update', this.onTimer);
     return this;
 };
 
@@ -1508,10 +1506,10 @@ AnimationSession.prototype.resume = function () {
         var app = pc.Application.getApplication();
         app.on('update', this.onTimer);
     }
-}; 
+};
 
-AnimationSession.prototype.fadeOut = function (duration) {  
-    this.fadeBegTime = this.curTime; 
+AnimationSession.prototype.fadeOut = function (duration) {
+    this.fadeBegTime = this.curTime;
     this.fadeTime = this.fadeBegTime;
     this.fadeEndTime = this.fadeBegTime + duration;
     this.fadeDir = -1;
@@ -1592,9 +1590,9 @@ AnimationComponent.prototype.stopClip = function () {
     }
 };
 
-AnimationComponent.prototype.crossFadeToClip = function (name, duration) { 
-    if (this.animClips[this.curClip] && this.animClips[name]) { 
-        // this.animClips[this.curClip].fadeTo(this.animClips[name], duration); 
+AnimationComponent.prototype.crossFadeToClip = function (name, duration) {
+    if (this.animClips[this.curClip] && this.animClips[name]) {
+        // this.animClips[this.curClip].fadeTo(this.animClips[name], duration);
         this.animClips[this.curClip].fadeOut(duration);
         this.animClips[name].fadeIn(duration);
         this.curClip = name;

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -1194,7 +1194,7 @@ var AnimationSession = function AnimationSession(playable, targets) {
     this.blendWeights = {};
 
     // ontimer function for playback
-    var self = this;
+    var self = this; 
     this.onTimer = function (dt) {
         self.curTime += (self.bySpeed * dt);
         self.accTime += (self.bySpeed * dt);
@@ -1215,18 +1215,18 @@ var AnimationSession = function AnimationSession(playable, targets) {
             for (var i = 0; i < self.animEvents.length; i ++)
                 self.animEvents[i].triggered = false;
         }
-        if (self.curTime < self.begTime)
+        if (self.curTime < self.begTime) 
             self.curTime += duration;
 
         if(self.fadeDir) {
             self.fadeTime +=  dt;// (self.bySpeed * dt);
             if(self.fadeTime >= self.fadeEndTime) {
-                if(self.fadeDir === 1) { // fadein completed
+                if(self.fadeDir === 1) { // fadein completed 
                     self.fadeDir = 0;
                     self.fadeBegTime = -1;
                     self.fadeEndTime = -1;
-                    self.fadeTime = -1;
-                } else if (self.fadeDir === -1) { // fadeout completed
+                    self.fadeTime = -1; 
+                } else if (self.fadeDir === -1) { // fadeout completed 
                     self.stop();
                     return;
                 }
@@ -1237,12 +1237,12 @@ var AnimationSession = function AnimationSession(playable, targets) {
         self.invokeByTime(self.curTime);
     };
 };
-
+ 
 AnimationSession.app = null;
 
 // blend related==========================================================
 AnimationSession.prototype.setBlend = function(blendValue, weight, curveName){
-    if(blendValue instanceof AnimationClip){
+    if(blendValue instanceof AnimationClip) {
         if(!curveName || curveName === "")
             curveName = "__default__";
         this.blendables[curveName] = blendValue;
@@ -1275,7 +1275,7 @@ AnimationSession.prototype.unsetBlend = function(curveName) {
         delete this.blendables[curveName];
         delete this.blendWeights[curveName];
     }
-};
+}; 
 
 // events related
 AnimationSession.prototype.on = function (name, time, fnCallback, context, parameter) {
@@ -1413,7 +1413,7 @@ AnimationSession.prototype.updateToTarget = function (input) {
     }
 };
 
-AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndTime, fadeTime) {
+AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndTime, fadeTime) { 
     var i, p;
     var input = this.playable.eval(time);
     // blend related==========================================================
@@ -1439,7 +1439,7 @@ AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEn
         input.curveKeyable[cname] = resKey;
     }
 
-    if(fadeDir === 0 || fadeTime < fadeBegTime || fadeTime > fadeEndTime)
+    if(fadeDir === 0 || fadeTime < fadeBegTime || fadeTime > fadeEndTime) 
         this.updateToTarget(input);
     else {
         p = (fadeTime - fadeBegTime) / (fadeEndTime - fadeBegTime);
@@ -1447,7 +1447,7 @@ AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEn
             p = 1 - p;
         this.blendToTarget(input, p);
     }
-};
+};  
 
 AnimationSession.prototype.play = function (playable, animTargets) {
     var i;
@@ -1516,8 +1516,8 @@ AnimationSession.prototype.resume = function () {
     }
 };
 
-AnimationSession.prototype.fadeOut = function (duration) {
-    this.fadeBegTime = this.curTime;
+AnimationSession.prototype.fadeOut = function (duration) { 
+    this.fadeBegTime = this.curTime; 
     this.fadeTime = this.fadeBegTime;
     this.fadeEndTime = this.fadeBegTime + duration;
     this.fadeDir = -1;
@@ -1599,8 +1599,8 @@ AnimationComponent.prototype.stopClip = function () {
 };
 
 AnimationComponent.prototype.crossFadeToClip = function (name, duration) {
-    if (this.animClips[this.curClip] && this.animClips[name]) {
-        // this.animClips[this.curClip].fadeTo(this.animClips[name], duration);
+    if (this.animClips[this.curClip] && this.animClips[name]) { 
+        // this.animClips[this.curClip].fadeTo(this.animClips[name], duration); 
         this.animClips[this.curClip].fadeOut(duration);
         this.animClips[name].fadeIn(duration);
         this.curClip = name;

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -1140,8 +1140,8 @@ AnimationClip.prototype.setInterpolationType = function (type) {
 // * class AnimationEvent:
 // *===============================================================================================================
 var AnimationEvent = function AnimationEvent(name, time, fnCallback, context, parameter) {
-    this.name = name;
-    this.triggerTime = time; 
+    this.name = name; 
+    this.triggerTime = time;
     this.fnCallback = fnCallback;
     this.context = context || this;
     this.parameter = parameter;
@@ -1149,9 +1149,9 @@ var AnimationEvent = function AnimationEvent(name, time, fnCallback, context, pa
     this.triggered = false;
 };
 
-AnimationEvent.prototype.invoke = function () { 
+AnimationEvent.prototype.invoke = function () {
     if (this.fnCallback) {
-        this.fnCallback.call(this.context, this.parameter); 
+        this.fnCallback.call(this.context, this.parameter);
         this.triggered = true;
     }
 };
@@ -1476,7 +1476,7 @@ AnimationSession.prototype.play = function (playable, animTargets) {
         this.animTargets = animTargets; 
 
     // reset events
-    for (i = 0; i < this.animEvents.length; i ++)
+    for (i = 0; i < this.animEvents.length; i ++) 
         this.animEvents[i].triggered = false;
 
     // reset events

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -1142,16 +1142,16 @@ AnimationClip.prototype.setInterpolationType = function (type) {
 var AnimationEvent = function AnimationEvent(name, time, fnCallback, context, parameter) {
     this.name = name;
     this.triggerTime = time;
-    this.fnCallback = fnCallback;
+    this.fnCallback = fnCallback; 
     this.context = context || this;
     this.parameter = parameter;
 
     this.triggered = false;
 };
 
-AnimationEvent.prototype.invoke = function () {
+AnimationEvent.prototype.invoke = function () { 
     if (this.fnCallback) {
-        this.fnCallback.call(this.context, this.parameter);
+        this.fnCallback.call(this.context, this.parameter); 
         this.triggered = true;
     }
 };
@@ -1199,8 +1199,8 @@ var AnimationSession = function AnimationSession(playable, targets) {
         self.curTime += (self.bySpeed * dt);
         self.accTime += (self.bySpeed * dt);
 
-        if (!self.isPlaying ||// not playing
-            (!self.loop && (self.curTime < self.begTime || self.curTime > self.endTime))){ // not in range
+        if (!self.isPlaying ||// not playing 
+            (!self.loop && (self.curTime < self.begTime || self.curTime > self.endTime))){ // not in range 
             self.invokeByTime(self.curTime);
             self.stop();
             self.invokeByName("stop");
@@ -1474,7 +1474,7 @@ AnimationSession.prototype.play = function (playable, animTargets) {
     if (!animTargets && typeof playable.getAnimTargets === "function")
         this.animTargets = playable.getAnimTargets();
     else
-        this.animTargets = animTargets;
+        this.animTargets = animTargets; 
 
     // reset events
     for (i = 0; i < this.animEvents.length; i ++)
@@ -1485,7 +1485,7 @@ AnimationSession.prototype.play = function (playable, animTargets) {
         this.animEvents[i].triggered = false;
 
     var app = pc.Application.getApplication();
-    app.on('update', this.onTimer);
+    app.on('update', this.onTimer); 
     return this;
 };
 

--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -1,4 +1,4 @@
-(function () {  
+(function () {
     // Math utility functions
     function nearestPow2(n) {
         return Math.pow(2, Math.round(Math.log(n) / Math.log(2)));

--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -1,4 +1,5 @@
 (function () {
+
     // Math utility functions
     function nearestPow2(n) {
         return Math.pow(2, Math.round(Math.log(n) / Math.log(2)));
@@ -922,12 +923,9 @@
         if (data.hasOwnProperty('camera')) {
             var gltf = resources.gltf;
             var camera = gltf.cameras[data.camera];
-
             var options = {};
-
             if (camera.type === 'perspective') {
                 options.type = pc.PROJECTION_PERSPECTIVE;
-
                 if (camera.hasOwnProperty('perspective')) {
                     var perspective = camera.perspective;
                     if (perspective.hasOwnProperty('aspectRatio')) {
@@ -941,19 +939,15 @@
                 }
             } else if (camera.type === 'orthographic') {
                 options.type = pc.PROJECTION_ORTHOGRAPHIC;
-
                 if (camera.hasOwnProperty('orthographic')) {
                     var orthographic = camera.orthographic;
-
                     options.aspectRatio = orthographic.xmag / orthographic.ymag;
                     options.orthoHeight = orthographic.ymag * 0.5;
                     options.farClip = orthographic.zfar;
                     options.nearClip = orthographic.znear;
                 }
             }
-
             entity.addComponent('camera', options);
-
             // Diable loaded cameras by default and leave it to the application to enable them
             entity.camera.enabled = false;
         }

--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -1,4 +1,4 @@
-(function () {
+(function () { 
 
     // Math utility functions
     function nearestPow2(n) {

--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -1,5 +1,4 @@
 (function () { 
-
     // Math utility functions
     function nearestPow2(n) {
         return Math.pow(2, Math.round(Math.log(n) / Math.log(2)));

--- a/viewer/src/viewer.js
+++ b/viewer/src/viewer.js
@@ -162,7 +162,7 @@ Viewer.prototype = {
             this.animationClips = animationClips;
 
             // If we don't already have an animation component, create one.
-            // Note that this isn't really a 'true' component like those 
+            // Note that this isn't really a 'true' component like those
             // found in the engine...
             if (!this.gltf.animComponent) {
                 this.gltf.animComponent = new AnimationComponent();
@@ -233,7 +233,7 @@ function main() {
     // Handle dropped GLB/GLTF files
     document.addEventListener('dragover', function (event) {
         event.preventDefault();
-    }, false); 
+    }, false);
 
     document.addEventListener('drop', function (event) {
         event.preventDefault();
@@ -330,7 +330,7 @@ function main() {
                     loadFile(files[filename], files);
                 }
             };
-        }); 
+        });
 
     }, false);
 }


### PR DESCRIPTION
Fixes #

The only change is reimplementations of 
AnimationTarget.constructTargetNodes = function (root, vec3Scale, output) 
AnimationClip.prototype.transferToRoot = function (root)
in playcanvas-anim.js
Other code changes are due to merging and rebasing, please feel free to ignore. 

Tested with some glb animations:
Before improvement with old implementation 
1 viewer.js:170 transferToRoot test: 0.3330078125ms
2 viewer.js:170 transferToRoot test: 0.31298828125ms
3 viewer.js:170 transferToRoot test: 0.47119140625ms
4 viewer.js:170 transferToRoot test: 0.324951171875ms
5 viewer.js:170 transferToRoot test: 0.43994140625ms
6 viewer.js:170 transferToRoot test: 0.40185546875ms
7 viewer.js:170 transferToRoot test: 0.576904296875ms
8 viewer.js:170 transferToRoot test: 0.346923828125ms

After improvement with new implementation 
1 viewer.js:170 transferToRoot test: 0.26708984375ms
2 viewer.js:170 transferToRoot test: 0.244140625ms
3 viewer.js:170 transferToRoot test: 0.227783203125ms
4 viewer.js:170 transferToRoot test: 0.232177734375ms
5 viewer.js:170 transferToRoot test: 0.22607421875ms
6 viewer.js:170 transferToRoot test: 0.30615234375ms
7 viewer.js:170 transferToRoot test: 0.2138671875ms
8 viewer.js:170 transferToRoot test: 0.2099609375ms




I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
