### PR TITLE
Default Specular Color Fix

### DIFF
--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -342,7 +342,7 @@
                 material.specular.set(Math.pow(color[0], 1 / 2.2), Math.pow(color[1], 1 / 2.2), Math.pow(color[2], 1 / 2.2));
                 material.specularTint = true;
             } else {
-                material.specular.set(1, 1, 1);
+                material.specular.set(0, 0, 0);
                 material.specularTint = false;
             }
             if (specData.hasOwnProperty('glossinessFactor')) {


### PR DESCRIPTION
Change default specular color for KHR_materials_pbrSpecularGlossiness to BLACK (0,0,0)

Fixes #

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
