### PR TITLE
Add animation timeline for easier debugging

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -17,7 +17,7 @@
             <input  id="anim_pause"  type="button" value="||">
             <input  id="anim_slider" type="range" min="0" max="1" value="0" step="any">
             <span   id="anim_info"></span>
-			<canvas id="anim_timeline" width=1000 height=900></canvas>
+			<canvas id="anim_timeline" width=1000 height=200></canvas>
         </div>
         <div id="dropzone" class="dropzone">
             <!--

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -17,7 +17,14 @@
             <input  id="anim_pause"  type="button" value="||">
             <input  id="anim_slider" type="range" min="0" max="1" value="0" step="any">
             <span   id="anim_info"></span>
+            <input  id="anim_timeline_toggle" type="button" value="Timeline: Off">
 			<canvas id="anim_timeline" width=1000 height=200></canvas>
+            <div    id="anim_timeline_settings">
+            <!--
+                <input  id="anim_timeline_inc"  type="button" value="height++">
+                <input  id="anim_timeline_dec"  type="button" value="height--">
+            -->
+            </div>
         </div>
         <div id="dropzone" class="dropzone">
             <!--

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -14,9 +14,10 @@
     <body onload='main()'>
         <div id="anim">
             <select id="anim_select"></select>
-            <input type="button" id="anim_pause" value="||">
-            <input type="range" min="0" max="1" value="0" step="any" id="anim_slider">
-            <span id="anim_info"></span>
+            <input  id="anim_pause"  type="button" value="||">
+            <input  id="anim_slider" type="range" min="0" max="1" value="0" step="any">
+            <span   id="anim_info"></span>
+			<canvas id="anim_timeline" width=500 height=500></canvas>
         </div>
         <div id="dropzone" class="dropzone">
             <!--

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -19,12 +19,6 @@
             <span   id="anim_info"></span>
             <input  id="anim_timeline_toggle" type="button" value="Timeline: Off">
 			<canvas id="anim_timeline" width=1000 height=200></canvas>
-            <div    id="anim_timeline_settings">
-            <!--
-                <input  id="anim_timeline_inc"  type="button" value="height++">
-                <input  id="anim_timeline_dec"  type="button" value="height--">
-            -->
-            </div>
         </div>
         <div id="dropzone" class="dropzone">
             <!--

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -17,7 +17,7 @@
             <input  id="anim_pause"  type="button" value="||">
             <input  id="anim_slider" type="range" min="0" max="1" value="0" step="any">
             <span   id="anim_info"></span>
-			<canvas id="anim_timeline" width=500 height=500></canvas>
+			<canvas id="anim_timeline" width=1000 height=900></canvas>
         </div>
         <div id="dropzone" class="dropzone">
             <!--

--- a/viewer/src/viewer.js
+++ b/viewer/src/viewer.js
@@ -96,6 +96,11 @@ function Viewer() {
     this.setupAnimControls();
     this.timelineCurveHeight = 12;
     this.timelineDisable();
+    this.timelineColorLines        = "rgba(0,0,  0, 0.4)"; // grayish
+    this.timelineColorLinesHovered = "rgba(0,0,255, 0.8)"; // quite blue
+    this.timelineColorRectHovered  = "rgba(0,0,255, 0.1)"; // blueish transparent
+    this.timelineColorRectSelected = "rgba(0,255,0, 0.1)"; // greenish transparent
+    this.timelineColorLineSlider   = "white";
     
     // Press 'D' to delete the currently loaded model
     app.on('update', function () {
@@ -104,7 +109,7 @@ function Viewer() {
         }
         if (this.gltf && this.gltf.animComponent) {
             // mirror the playback time of the playing clip into the html range slider
-            const curTime = this.gltf.animComponent.getCurrentClip().session.curTime;
+            var curTime = this.gltf.animComponent.getCurrentClip().session.curTime;
             this.anim_slider.value = curTime;
         }
         this.renderTimeline();
@@ -266,9 +271,9 @@ Viewer.prototype = {
             // once we seek into the animation, stop the default playing
             this.pauseAnimationClips();
             // now set the seeked time for the last played clip
-            const clip = this.gltf.animComponent.getCurrentClip()
-            const session = clip.session;
-            const self = session;
+            var clip = this.gltf.animComponent.getCurrentClip()
+            var session = clip.session;
+            var self = session;
             session.curTime = curTime;
             self.showAt(self.curTime, self.fadeDir, self.fadeBegTime, self.fadeEndTime, self.fadeTime);
             self.invokeByTime(self.curTime);
@@ -279,7 +284,7 @@ Viewer.prototype = {
     
     switchToClipByName: function(clipName) {
         if (this.gltf && this.gltf.animComponent) {
-            const clip = this.gltf.animComponent.animClipsMap[clipName];
+            var clip = this.gltf.animComponent.animClipsMap[clipName];
             this.anim_info.innerHTML = clip.duration + "s " + clipName;
             this.gltf.animComponent.curClip = clipName;
             this.pauseAnimationClips();
@@ -356,7 +361,7 @@ Viewer.prototype = {
         var needPixels = 0;
         if (this.timelineEnabled && this.gltf && this.gltf.animComponent) {
             needPixels = this.clip.animCurves.length * this.timelineCurveHeight;
-            console.log("needPixels", needPixels);
+            //console.log("needPixels", needPixels);
             var thirdOfScreen = window.innerHeight / 3; // use max 1/3 of all height
             if (needPixels > thirdOfScreen) {
                 // if all animation curves dont fit into third of screen, just ignore the rest
@@ -374,14 +379,17 @@ Viewer.prototype = {
     timelineEnable: function() {
         this.anim_timeline.style.display = "";
         this.timelineEnabled = true;
-        this.anim_timeline_toggle.value = "Timeline: On";
+        this.anim_timeline_toggle.value = "Disable Timeline";
         this.timelineResize();
+        if ( (this.gltf && this.gltf.animComponent) === undefined) {
+            this.anim_info.innerHTML = "please load a gltf/glb with animation data to see the timeline \uD83C\uDF4B";
+        }
     },
     
     timelineDisable: function() {
         this.anim_timeline.style.display = "none";
         this.timelineEnabled = false;
-        this.anim_timeline_toggle.value = "Timeline: Off";
+        this.anim_timeline_toggle.value = "Enable Timeline";
         this.timelineResize();
     },
     
@@ -448,9 +456,9 @@ Viewer.prototype.renderTimeline = function() {
         ctx.lineWidth = 1;
         for (var animcurve_id = 0; animcurve_id < clip.animCurves.length; animcurve_id++) {
             var animCurve = clip.animCurves[animcurve_id];
-            var linecolor = "rgba(0,0,0, 0.4)";
+            var linecolor = this.timelineColorLines;
             if (animCurve == this.hoveredCurve) {
-                linecolor = "rgba(0,0,255, 0.8)";
+                linecolor = this.timelineColorLinesHovered;
             }
             var steptime = clip.duration / animCurve.animKeys.length;
             var eg250 = canvasWidth / animCurve.animKeys.length;
@@ -466,7 +474,7 @@ Viewer.prototype.renderTimeline = function() {
                 }
                 if (animKey == this.hoveredAnimKey) {
                     ctx.beginPath();
-                    ctx.fillStyle = "rgba(0,0,255, 0.1)"; // blueish
+                    ctx.fillStyle = this.timelineColorRectHovered;
                     ctx.fillRect( // left, top, width, height
                         left + 1, top + 1,
                         eg250 - 2, this.timelineCurveHeight - 2
@@ -475,7 +483,7 @@ Viewer.prototype.renderTimeline = function() {
                 }
                 if (animKey == this.selectedAnimKey) {
                     ctx.beginPath();
-                    ctx.fillStyle = "rgba(0,255,0, 0.1)"; // greenish
+                    ctx.fillStyle = this.timelineColorRectSelected;
                     ctx.fillRect( // left, top, width, height
                         left + 1, top + 1,
                         eg250 - 2, this.timelineCurveHeight - 2
@@ -487,7 +495,7 @@ Viewer.prototype.renderTimeline = function() {
         }
         // draw the time slider position
         var slider_left = clip.session.curTime * multiplier;
-        ctx.strokeStyle = "white";
+        ctx.strokeStyle = this.timelineColorLineSlider;
         ctx.beginPath();
         ctx.moveTo(slider_left, 0);
         ctx.lineTo(slider_left, ctx.canvas.height);
@@ -517,7 +525,7 @@ function loadScript(src) {
 }
 
 select_add_option = function(select, option_text) {
-    const option = document.createElement("option");
+    var option = document.createElement("option");
     option.text = option_text;
     select.add(option);
     return option;

--- a/viewer/src/viewer.js
+++ b/viewer/src/viewer.js
@@ -195,13 +195,17 @@ Viewer.prototype = {
                 animationClips[i].transferToRoot(this.gltf);
                 this.gltf.animComponent.addClip(animationClips[i]);
             }
-            this.gltf.animComponent.playClip(animationClips[0].name);
+            //this.gltf.animComponent.playClip(animationClips[0].name);
+            this.gltf.animComponent.curClip = animationClips[0].name;
+            this.pauseAnimationClips();
+            this.playCurrentAnimationClip();
             
             select_remove_options(this.anim_select);
             for (i = 0; i < animationClips.length; i++) {
                 select_add_option(this.anim_select, animationClips[i].name);
             }
             this.anim_info.innerHTML = animationClips.length + " animation clips loaded";
+            this.renderTimeline();
         }
 
         // Focus the camera on the newly loaded scene
@@ -237,9 +241,12 @@ Viewer.prototype = {
     playCurrentAnimationClip: function() {
         if (this.gltf && this.gltf.animComponent) {
             //this.gltf.animComponent.getCurrentClip().resume(); // resume doesn't work yet
-            this.gltf.animComponent.getCurrentClip().play(); // just play it again, until resume() works
+            var clip = this.gltf.animComponent.getCurrentClip();
+            clip.play(); // just play it again, until resume() works
+            this.anim_slider.max = clip.duration;
             this.playing = true;
             this.anim_pause.value = "||";
+            this.renderTimeline();
         }
     },
     
@@ -271,7 +278,6 @@ Viewer.prototype = {
         if (this.gltf && this.gltf.animComponent) {
             const clip = this.gltf.animComponent.animClipsMap[clipName];
             this.anim_info.innerHTML = clip.duration + "s " + clipName;
-            this.anim_slider.max = clip.duration;
             this.gltf.animComponent.curClip = clipName;
             this.pauseAnimationClips();
             this.playCurrentAnimationClip();
@@ -305,8 +311,22 @@ Viewer.prototype = {
         }.bind(this);
         
         this.anim_info = document.getElementById("anim_info");
+        
+        this.anim_timeline = document.getElementById("anim_timeline");
+        this.anim_timeline_context = this.anim_timeline.getContext("2d");
     }
 };
+
+Viewer.prototype.renderTimeline = function() {
+    if (this.gltf && this.gltf.animComponent) {
+        const clip = this.gltf.animComponent.getCurrentClip();
+        var left = 0;
+        var top = 0;
+        //this.anim_timeline_context.font = "14px 'Lucida Console'";
+        this.anim_timeline_context.fillText("hai" + clip.name, 10, 20);
+        //this.anim_timeline_context.fillText("hai", 10, 20);
+    }
+}
 
 function getParameterByName(name, url) {
     if (!url) url = window.location.href;

--- a/viewer/src/viewer.js
+++ b/viewer/src/viewer.js
@@ -376,12 +376,12 @@ Viewer.prototype = {
         if (this.clip === undefined) {
             return;
         }
-        var curve_id = Math.floor(top / this.timelineCurveHeight);
-        var curve = this.clip.animCurves[curve_id];
+        this.curve_id = Math.floor(top / this.timelineCurveHeight);
+        var curve = this.clip.animCurves[this.curve_id];
         if (curve !== undefined) {
             var eg250 = window.innerWidth / curve.animKeys.length; // 1000px / 4 animkeys
-            var animkey_id = Math.floor(left / eg250);
-            var animKey = curve.animKeys[animkey_id];
+            this.animkey_id = Math.floor(left / eg250);
+            var animKey = curve.animKeys[this.animkey_id];
             this.hoveredCurve = curve;
             this.hoveredAnimKey = animKey;
         }
@@ -390,6 +390,18 @@ Viewer.prototype = {
     timelineMouseClickLeft: function(left, top) {
         this.selectedCurve     = this.hoveredCurve;
         this.selectedAnimKey   = this.hoveredAnimKey;
+        if (this.gltf && this.gltf.animComponent) {
+            var msg = "open f12/devtools and check <code>viewer.selectedAnimKey</code> or ";
+            msg += "<code>";
+            if (this.curve_id !== undefined)
+                msg += "viewer.clip.animCurves[" + this.curve_id + "]";
+            if (this.animkey_id !== undefined)
+                msg += ".animKeys[" + this.animkey_id + "]";
+            msg += "</code> \uD83D\uDD75";
+            this.anim_info.innerHTML = msg;
+        } else {
+            this.anim_info.innerHTML = "please load a gltf/glb with animation data to use the timeline \uD83C\uDF4B";
+        }
     },
     
     timelineMouseClickMiddle: function(left, top) {

--- a/viewer/src/viewer.js
+++ b/viewer/src/viewer.js
@@ -203,7 +203,6 @@ Viewer.prototype = {
                 animationClips[i].transferToRoot(this.gltf);
                 this.gltf.animComponent.addClip(animationClips[i]);
             }
-            //this.gltf.animComponent.playClip(animationClips[0].name);
             this.gltf.animComponent.curClip = animationClips[0].name;
             this.pauseAnimationClips();
             this.playCurrentAnimationClip();
@@ -271,7 +270,7 @@ Viewer.prototype = {
             // once we seek into the animation, stop the default playing
             this.pauseAnimationClips();
             // now set the seeked time for the last played clip
-            var clip = this.gltf.animComponent.getCurrentClip()
+            var clip = this.gltf.animComponent.getCurrentClip();
             var session = clip.session;
             var self = session;
             session.curTime = curTime;

--- a/viewer/src/viewer.js
+++ b/viewer/src/viewer.js
@@ -247,6 +247,7 @@ Viewer.prototype = {
             this.playing = true;
             this.anim_pause.value = "||";
             this.renderTimeline();
+            this.clip = clip; // quick access for f12 devtools
         }
     },
     
@@ -314,16 +315,66 @@ Viewer.prototype = {
         
         this.anim_timeline = document.getElementById("anim_timeline");
         this.anim_timeline_context = this.anim_timeline.getContext("2d");
+        this.anim_timeline.onmousemove = function(e) {
+            var pos_left = e.pageX - e.currentTarget.offsetLeft;
+            var pos_top = e.pageY - e.currentTarget.offsetTop;
+            console.log(pos_left, pos_top);
+            if (this.clip === undefined) {
+                return;
+                
+            }
+            var curve_id = Math.floor(pos_top / 20);
+            var curve = this.clip.animCurves[curve_id];
+            if (curve) {
+                console.log(curve);
+                
+            }
+        }.bind(this);
     }
 };
 
 Viewer.prototype.renderTimeline = function() {
     if (this.gltf && this.gltf.animComponent) {
+        const ctx = this.anim_timeline_context;
         const clip = this.gltf.animComponent.getCurrentClip();
+        const canvasWidth = ctx.canvas.width;
+        const multiplier = canvasWidth / clip.duration; // multiply with this for animKey.time to canvas "left"
+        
+        
         var left = 0;
         var top = 0;
         //this.anim_timeline_context.font = "14px 'Lucida Console'";
-        this.anim_timeline_context.fillText("hai" + clip.name, 10, 20);
+        ctx.fillText("Clip: " + clip.name, 10, 20);
+        top += 20;
+        
+        
+        ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+        
+        // e.g. width==1000, 4 animCurves
+        // 4 animcurves need 3 separators [ 1 | 2 | 3 | 4]
+        // first separator will be at 1000/4==250
+        for (var animCurve of clip.animCurves) {
+            ctx.fillText(animCurve.name, 10, top);
+            
+            const steptime = clip.duration / animCurve.animKeys.length;
+            console.log("Steptime: ", steptime);
+            const eg250 = canvasWidth / animCurve.animKeys.length;
+            //for (var animKey of animCurve.animKeys) {
+            // e.g. length==4, loop over [1,2,3]
+            for (var i=1; i<animCurve.animKeys.length; i++) {
+                
+                
+                //const left = (animKey.time - steptime) * multiplier;
+                const left = i * eg250;
+                ctx.fillText("|", left, top);
+                //top += 20;
+            }
+            
+            
+            top += 20;
+            
+        }
         //this.anim_timeline_context.fillText("hai", 10, 20);
     }
 }

--- a/viewer/src/viewer.js
+++ b/viewer/src/viewer.js
@@ -249,6 +249,7 @@ Viewer.prototype = {
             this.playing = true;
             this.anim_pause.value = "||";
             this.clip = clip; // quick access for f12 devtools
+            this.timelineResize();
         }
     },
     
@@ -345,24 +346,43 @@ Viewer.prototype = {
             this.hoveredCurve = undefined;
             this.hoveredAnimKey = undefined;
         }.bind(this);
-        this.anim_timeline.width = window.innerWidth;
-        this.anim_timeline.style.top = (window.innerHeight - 200) + "px";
+        
         window.onresize = function () {
-            this.anim_timeline.width = window.innerWidth;
-            this.anim_timeline.style.top = (window.innerHeight - 200) + "px";
+            this.timelineResize();
         }.bind(this);
+    },
+    
+    timelineResize: function() {
+        var needPixels = 0;
+        if (this.timelineEnabled && this.gltf && this.gltf.animComponent) {
+            needPixels = this.clip.animCurves.length * this.timelineCurveHeight;
+            console.log("needPixels", needPixels);
+            var thirdOfScreen = window.innerHeight / 3; // use max 1/3 of all height
+            if (needPixels > thirdOfScreen) {
+                // if all animation curves dont fit into third of screen, just ignore the rest
+                // either implement scrolling or decrease this.timelineCurveHeight automatically
+                needPixels = thirdOfScreen;
+            } else {
+                // smallest timeline height possible, keep this
+            }
+        }
+        this.anim_timeline.width = window.innerWidth;
+        this.anim_timeline.height = needPixels;
+        this.anim_timeline.style.top = (window.innerHeight - needPixels) + "px";
     },
     
     timelineEnable: function() {
         this.anim_timeline.style.display = "";
         this.timelineEnabled = true;
         this.anim_timeline_toggle.value = "Timeline: On";
+        this.timelineResize();
     },
     
     timelineDisable: function() {
         this.anim_timeline.style.display = "none";
         this.timelineEnabled = false;
         this.anim_timeline_toggle.value = "Timeline: Off";
+        this.timelineResize();
     },
     
     timelineToggle: function() {

--- a/viewer/src/viewer.js
+++ b/viewer/src/viewer.js
@@ -324,12 +324,20 @@ Viewer.prototype = {
             }
             var curve_id = Math.floor(pos_top / this.timelineCurveHeight);
             var curve = this.clip.animCurves[curve_id];
-            this.hoveredCurve = curve;
+            if (curve !== undefined) {
+                var eg250 = window.innerWidth / curve.animKeys.length; // 1000px / 4 animkeys
+                var animkey_id = Math.floor(pos_left / eg250);
+                var animKey = curve.animKeys[animkey_id];
+                this.hoveredCurve = curve;
+                this.hoveredAnimKey = animKey;
+            }
             this.renderTimeline();
         }.bind(this);
         this.anim_timeline.width = window.innerWidth;
+        this.anim_timeline.style.top = (window.innerHeight - 200) + "px";
         window.onresize = function () {
             this.anim_timeline.width = window.innerWidth;
+            this.anim_timeline.style.top = (window.innerHeight - 200) + "px";
         }.bind(this);
     }
 };
@@ -352,45 +360,39 @@ Viewer.prototype.renderTimeline = function() {
         // 4 animcurves need 3 separators [ 1 | 2 | 3 | 4]
         // first separator will be at 1000/4==250
         for (var animCurve of clip.animCurves) {
-            
+            var linecolor = "rgba(0,0,0, 0.4)";
             if (animCurve == this.hoveredCurve) {
-                ctx.strokeStyle = "red";
-                ctx.fillStyle = "red";
-            } else {
-                ctx.strokeStyle = "rgba(0,0,0, 0.4)";
-                ctx.fillStyle = "black";
+                linecolor = "blue";
             }
-            
-            //ctx.fillText(animCurve.name, 10, top);
-            
             const steptime = clip.duration / animCurve.animKeys.length;
-            //console.log("Steptime: ", steptime);
             const eg250 = canvasWidth / animCurve.animKeys.length;
-            //for (var animKey of animCurve.animKeys) {
-            // e.g. length==4, loop over [1,2,3]
-            for (var i=1; i<animCurve.animKeys.length; i++) {
-                
-                //const left = (animKey.time - steptime) * multiplier;
+            for (var i=0; i<animCurve.animKeys.length; i++) {
+                var animKey = animCurve.animKeys[i];
                 const left = i * eg250;
-                //ctx.fillText("|", left, top);
-                
-                ctx.beginPath();
-                ctx.moveTo(left, top);
-                ctx.lineTo(left, top + this.timelineCurveHeight);
-                ctx.stroke();
-                
-                //top += 20;
+                if (left != 0) { // dont draw a marker line on left==0px
+                    //const left = (animKey.time - steptime) * multiplier;
+                    //ctx.fillText("|", left, top);
+                    ctx.beginPath();
+                    ctx.strokeStyle = linecolor;
+                    ctx.moveTo(left, top);
+                    ctx.lineTo(left, top + this.timelineCurveHeight);
+                    ctx.stroke();
+                }
+                if (animKey == this.hoveredAnimKey) {
+                    ctx.beginPath();
+                    ctx.fillStyle = "rgba(0,0,255, 0.2)";
+                    ctx.fillRect( // left, top, width, height
+                        left + 1     , top + 1,
+                        eg250 - 2, this.timelineCurveHeight - 2
+                    );
+                    ctx.stroke();
+                }
             }
-            
-            
             top += this.timelineCurveHeight;
-            
         }
-        //this.anim_timeline_context.fillText("hai", 10, 20);
-        
-        // draw the position
+        // draw the time slider position
         var slider_left = clip.session.curTime * multiplier;
-        ctx.strokeStyle = "lime";
+        ctx.strokeStyle = "white";
         ctx.beginPath();
         ctx.moveTo(slider_left, 0);
         ctx.lineTo(slider_left, ctx.canvas.height);

--- a/viewer/src/viewer.js
+++ b/viewer/src/viewer.js
@@ -318,17 +318,13 @@ Viewer.prototype = {
         this.anim_timeline.onmousemove = function(e) {
             var pos_left = e.pageX - e.currentTarget.offsetLeft;
             var pos_top = e.pageY - e.currentTarget.offsetTop;
-            console.log(pos_left, pos_top);
             if (this.clip === undefined) {
                 return;
-                
             }
             var curve_id = Math.floor(pos_top / 20);
             var curve = this.clip.animCurves[curve_id];
-            if (curve) {
-                console.log(curve);
-                
-            }
+            this.hoveredCurve = curve;
+            this.renderTimeline();
         }.bind(this);
     }
 };
@@ -355,15 +351,20 @@ Viewer.prototype.renderTimeline = function() {
         // 4 animcurves need 3 separators [ 1 | 2 | 3 | 4]
         // first separator will be at 1000/4==250
         for (var animCurve of clip.animCurves) {
+            
+            if (animCurve == this.hoveredCurve)
+                ctx.fillStyle = "red";
+            else
+                ctx.fillStyle = "black";
+            
             ctx.fillText(animCurve.name, 10, top);
             
             const steptime = clip.duration / animCurve.animKeys.length;
-            console.log("Steptime: ", steptime);
+            //console.log("Steptime: ", steptime);
             const eg250 = canvasWidth / animCurve.animKeys.length;
             //for (var animKey of animCurve.animKeys) {
             // e.g. length==4, loop over [1,2,3]
             for (var i=1; i<animCurve.animKeys.length; i++) {
-                
                 
                 //const left = (animKey.time - steptime) * multiplier;
                 const left = i * eg250;

--- a/viewer/styles.css
+++ b/viewer/styles.css
@@ -19,7 +19,3 @@ body {
 	border-top: 1px solid rgba(0, 0, 0, 0.1);
     left: 0px;
 }
-
-#anim_timeline_settings {
-	display: inline;
-}

--- a/viewer/styles.css
+++ b/viewer/styles.css
@@ -16,5 +16,10 @@ body {
 
 #anim_timeline {
 	position: absolute;
-	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-top: 1px solid rgba(0, 0, 0, 0.1);
+    left: 0px;
+}
+
+#anim_timeline_settings {
+	display: inline;
 }

--- a/viewer/styles.css
+++ b/viewer/styles.css
@@ -1,21 +1,21 @@
 body {
-	background-color: #AAAAAA;
-	margin: 0;
-	overflow: hidden;
+    background-color: #AAAAAA;
+    margin: 0;
+    overflow: hidden;
 }
 
 .dropzone {
-	font-family: Arial, Helvetica, sans-serif;
-	text-align: center;
-	font-size: large;
+    font-family: Arial, Helvetica, sans-serif;
+    text-align: center;
+    font-size: large;
 }
 
 #anim {
-	position: absolute;
+    position: absolute;
 }
 
 #anim_timeline {
-	position: absolute;
-	border-top: 1px solid rgba(0, 0, 0, 0.1);
+    position: absolute;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
     left: 0px;
 }

--- a/viewer/styles.css
+++ b/viewer/styles.css
@@ -13,3 +13,8 @@ body {
 #anim {
 	position: absolute;
 }
+
+#anim_timeline {
+	position: absolute;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
I aim to fix the animation bugs, but it was very cumbersome/confusing to only use f12/devtools to peek into all the animation curves/keys, which might need an inspection to figure out the bugs. This PR generates a pretty dense canvas to visualize the animation data, so its possible to just pick what you want with a simple mouse click, then inspect the selection in f12/devtools via `viewer.selectedAnimKey`.

Online demo: https://killtube.org/playcanvas-gltf/viewer/

![pc_timeline](https://user-images.githubusercontent.com/5236548/46928092-193de480-d039-11e8-83fa-0cf9fbe449e8.png)

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
