### PR TITLE
Assign Mesh Morph Weights

### DIFF
--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -991,6 +991,10 @@
             );
             mesh.aabb = aabb;
 
+            if (data.hasOwnProperty('weights')) {
+                mesh.weights = data.weights;
+            }
+
             if (primitive.hasOwnProperty('targets')) {
                 var targets = [];
 


### PR DESCRIPTION
Need to assign mesh.weights so its get used in CreateModel

Fixes #

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
