### PR TITLE
jsdoc for playcanvas-anim.js

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "types/playcanvas"]
+	path = types/playcanvas
+	url = https://github.com/Neoflash1979/playcanvas-typings

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -3,9 +3,23 @@
 // *
 // *===============================================================================================================
 var AnimationKeyableType = { NUM: 0, VEC: 1, QUAT: 2 };
-var AnimationKeyable = function AnimationKeyable(type, time, value) {
+
+/**
+ * @constructor
+ * @param {idk} type 
+ * @param {idk} time 
+ * @param {idk} value 
+ */
+
+var AnimationKeyable = function (type, time, value) {
     this.init(type, time, value);
 };
+
+/**
+ * @param {idk} type
+ * @param {idk} time
+ * @param {idk} value
+ */
 
 AnimationKeyable.prototype.init = function (type, time, value) {
     this.type = type || AnimationKeyableType.NUM;
@@ -21,6 +35,10 @@ AnimationKeyable.prototype.init = function (type, time, value) {
     }
     return this;
 };
+
+/**
+ * @param {idk} keyable
+ */
 
 AnimationKeyable.prototype.copy = function (keyable) {
     if (!keyable)
@@ -42,8 +60,14 @@ AnimationKeyable.prototype.clone = function () {
     return cloned;
 };
 
-// static function for lack of overloaded operator
-// return keyable1 + keyable2
+/**
+ * @param {idk} keyable1
+ * @param {idk} keyable2
+ * @summary
+ * static function for lack of overloaded operator
+ * return keyable1 + keyable2
+ */
+
 AnimationKeyable.sum = function (keyable1, keyable2) {
     if (!keyable1 || !keyable2 || keyable1.type != keyable2)
         return null;
@@ -61,7 +85,12 @@ AnimationKeyable.sum = function (keyable1, keyable2) {
     return resKeyable;
 };
 
-// return keyable1 - keyable2
+/**
+ * @param {idk} keyable1
+ * @param {idk} keyable2
+ * @summary return keyable1 - keyable2
+ */
+
 AnimationKeyable.minus = function (keyable1, keyable2) {
     if (!keyable1 || !keyable2 || keyable1.type != keyable2)
         return null;
@@ -79,7 +108,12 @@ AnimationKeyable.minus = function (keyable1, keyable2) {
     return resKeyable;
 };
 
-// return keyable * coeff
+/**
+ * @param {idk} keyable
+ * @param {idk} coeff
+ * @summary return keyable * coeff
+ */
+
 AnimationKeyable.mul = function (keyable, coeff) {
     if (!keyable)
         return null;
@@ -98,6 +132,10 @@ AnimationKeyable.mul = function (keyable, coeff) {
     return resKeyable;
 };
 
+/**
+ * @param {idk} keyable
+ * @param {idk} coeff
+ */
 // return keyable / coeff
 AnimationKeyable.div = function (keyable, coeff) {
     if (coeff === 0)
@@ -105,6 +143,13 @@ AnimationKeyable.div = function (keyable, coeff) {
 
     return AnimationKeyable.mul(keyable, 1 / coeff);
 };
+
+/**
+ * @param {idk} keyable1
+ * @param {idk} keyable2
+ * @param {idk} p
+ * @param {idk} cacheValue
+ */
 
 AnimationKeyable.linearBlend = function (keyable1, keyable2, p, cacheValue) {
     if (!keyable1 || !keyable2 || keyable1.type !== keyable2.type)
@@ -135,6 +180,12 @@ AnimationKeyable.linearBlend = function (keyable1, keyable2, p, cacheValue) {
     return resKeyable;
 };
 
+/**
+ * @param {idk} value1
+ * @param {idk} value2
+ * @param {idk} p
+ */
+
 AnimationKeyable.linearBlendValue = function (value1, value2, p) {
     var valRes;
 
@@ -163,7 +214,13 @@ AnimationKeyable.linearBlendValue = function (value1, value2, p) {
 // *                        one AnimationCurve has a [] collection of AnimationTargets
 // *                        one AnimationClip has a {} dictionary of AnimationTargets, keyname matches curvename
 // *===============================================================================================================
-var AnimationTarget = function AnimationTarget(targetNode, targetPath, targetProp) {
+/**
+ * @constructor
+ * @param {idk} targetNode
+ * @param {idk} targetPath
+ * @param {idk} targetProp
+ */
+var AnimationTarget = function (targetNode, targetPath, targetProp) {
     this.targetNode = targetNode;
     this.targetPath = targetPath;
     this.targetProp = targetProp;
@@ -181,6 +238,10 @@ AnimationTarget.prototype.toString = function (){
     return str;
 };
 
+/**
+ * @param {AnimationTarget} target
+ */
+
 AnimationTarget.prototype.copy = function (target) {
     if (target) {
         this.targetNode = target.targetNode;
@@ -195,7 +256,12 @@ AnimationTarget.prototype.clone = function () {
     return cloned;
 };
 
-// based on current target[path]'s value, blend in value by p
+/**
+ * @param {idk} value
+ * @param {idk} p
+ * @summary based on current target[path]'s value, blend in value by p
+ */
+
 AnimationTarget.prototype.blendToTarget = function (value, p) {
     if ((typeof value === "undefined") || p > 1 || p <= 0)// p===0 remain prev
         return;
@@ -256,6 +322,10 @@ AnimationTarget.prototype.blendToTarget = function (value, p) {
     }*/
 };
 
+/**
+ * @param {idk} value
+ */
+
 AnimationTarget.prototype.updateToTarget = function (value) {
     if ((typeof value === "undefined"))
         return;
@@ -305,6 +375,11 @@ AnimationTarget.prototype.updateToTarget = function (value) {
 };
 
 // static function
+/**
+ * @param {idk} root
+ * @param {idk} vec3Scale
+ * @param {idk} output
+ */
 AnimationTarget.constructTargetNodes = function (root, vec3Scale, output) {
     if (!root)
         return;
@@ -321,6 +396,9 @@ AnimationTarget.constructTargetNodes = function (root, vec3Scale, output) {
 };
 
 // static function
+/**
+ * @param {idk} node
+ */
 AnimationTarget.getLocalScale = function (node) {
     if (!node)
         return;
@@ -347,7 +425,11 @@ AnimationTarget.getLocalScale = function (node) {
 // *===============================================================================================================
 var AnimationCurveType = { LINEAR: 0, STEP: 1, CUBIC: 2, CUBICSPLINE_GLTF: 3 };
 
-var AnimationCurve = function AnimationCurve() {
+/**
+ * @constructor
+ */
+
+var AnimationCurve = function () {
     AnimationCurve.count ++;
     this.name = "curve" + AnimationCurve.count.toString();
     this.type = AnimationCurveType.LINEAR;
@@ -386,6 +468,10 @@ Object.defineProperty(AnimationCurve.prototype, 'bySpeed', {
     }
 });
 
+/**
+ * @param {idk} curve
+ */
+
 AnimationCurve.prototype.copy = function (curve) {
     var i;
 
@@ -412,10 +498,22 @@ AnimationCurve.prototype.clone = function () {
     return new AnimationCurve().copy(this);
 };
 
+/**
+ * @param {idk} targetNode
+ * @param {idk} targetPath
+ * @param {idk} targetProp
+ */
+
 AnimationCurve.prototype.addTarget = function (targetNode, targetPath, targetProp) {
     var target = new AnimationTarget(targetNode, targetPath, targetProp);
     this.animTargets.push(target);
 };
+
+/**
+ * @param {idk} targetNode
+ * @param {idk} targetPath
+ * @param {idk} targetProp
+ */
 
 AnimationCurve.prototype.setTarget = function (targetNode, targetPath, targetProp) {
     this.animTargets = [];
@@ -437,13 +535,23 @@ AnimationCurve.prototype.resetSession = function () {
     this.session.loop = true;
 };
 
+/**
+ * @param {idk} keyable
+ * @param {idk} p
+ */
+
 AnimationCurve.prototype.blendToTarget = function (keyable, p) {
     this.session.blendToTarget(keyable, p);
 };
 
+/**
+ * @param {idk} keyable
+ */
+
 AnimationCurve.prototype.updateToTarget = function (keyable) {
     this.session.updateToTarget(keyable);
 };
+
 // this.animTargets wrapped in object, with curve name
 AnimationCurve.prototype.getAnimTargets = function () {
     var result = {};
@@ -452,11 +560,25 @@ AnimationCurve.prototype.getAnimTargets = function () {
 };
 
 // events related
+/**
+ * @param {idk} name
+ * @param {idk} time
+ * @param {idk} fnCallback
+ * @param {idk} context
+ * @param {idk} parameter
+ */
+
 AnimationCurve.prototype.on = function (name, time, fnCallback, context, parameter) {
     if (this.session)
         this.session.on(name, time, fnCallback, context, parameter);
     return this;
 };
+
+/**
+ * @param {idk} name
+ * @param {idk} time
+ * @param {idk} fnCallback
+ */
 
 AnimationCurve.prototype.off = function (name, time, fnCallback) {
     if (this.session)
@@ -470,9 +592,17 @@ AnimationCurve.prototype.removeAllEvents = function () {
     return this;
 };
 
+/**
+ * @param {idk} duration
+ */
+
 AnimationCurve.prototype.fadeIn = function (duration) {
     this.session.fadeIn(duration, this);
 };
+
+/**
+ * @param {idk} duration
+ */
 
 AnimationCurve.prototype.fadeOut = function (duration) {
     this.session.fadeOut(duration);
@@ -494,13 +624,31 @@ AnimationCurve.prototype.pause = function () {
     this.session.pause();
 };
 
+/**
+ * @param {idk} time
+ * @param {idk} fadeDir
+ * @param {idk} fadeBegTime
+ * @param {idk} fadeEndTime
+ * @param {idk} fadeTime
+ */
+
 AnimationCurve.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndTime, fadeTime) {
     this.session.showAt(time, fadeDir, fadeBegTime, fadeEndTime, fadeTime);
 };
 
+/**
+ * @param {idk} animKeys
+ */
+
 AnimationCurve.prototype.setAnimKeys = function (animKeys) {
     this.animKeys = animKeys;
 };
+
+/**
+ * @param {idk} type
+ * @param {idk} time
+ * @param {idk} value
+ */
 
 AnimationCurve.prototype.insertKey = function (type, time, value) {
     if (this.keyableType != type)
@@ -530,6 +678,9 @@ AnimationCurve.prototype.insertKey = function (type, time, value) {
 };
 
 // 10/15
+/**
+ * @param {idk} keyable
+ */
 AnimationCurve.prototype.insertKeyable = function (keyable) {
     if (!keyable || this.keyableType != keyable.type)
         return;
@@ -556,6 +707,10 @@ AnimationCurve.prototype.insertKeyable = function (keyable) {
     this.animKeys.splice(pos, 0, keyable);
 };
 
+/**
+ * @param {idk} index
+ */
+
 AnimationCurve.prototype.removeKey = function (index) {
     if (index <= this.animKeys.length) {
         if (index == this.animKeys.length - 1)
@@ -569,10 +724,19 @@ AnimationCurve.prototype.removeAllKeys = function () {
     this.duration = 0;
 };
 
+/**
+ * @param {idk} time
+ */
+
 AnimationCurve.prototype.shiftKeyTime = function (time) {
     for (var i = 0; i < this.animKeys.length; i ++)
         this.animKeys[i].time += time;
 };
+
+/**
+ * @param {idk} tmBeg
+ * @param {idk} tmEnd
+ */
 
 AnimationCurve.prototype.getSubCurve = function (tmBeg, tmEnd) {
     var i;
@@ -602,6 +766,10 @@ AnimationCurve.prototype.getSubCurve = function (tmBeg, tmEnd) {
     subCurve.duration = (tmFirst === -1) ? 0 : (tmEnd - tmFirst);
     return subCurve;
 };
+
+/**
+ * @param {idk} time
+ */
 
 AnimationCurve.prototype.evalLINEAR = function (time) {
     if (!this.animKeys || this.animKeys.length === 0)
@@ -636,6 +804,12 @@ AnimationCurve.prototype.evalLINEAR = function (time) {
     resKey.time = time;
     return resKey;
 };
+
+/**
+ * @param {idk} time
+ * @param {idk} cacheKeyIdx
+ * @param {idk} cacheValue
+ */
 
 AnimationCurve.prototype.evalLINEAR_cache = function (time, cacheKeyIdx, cacheValue) { //1215
     if (!this.animKeys || this.animKeys.length === 0)
@@ -690,6 +864,10 @@ AnimationCurve.prototype.evalLINEAR_cache = function (time, cacheKeyIdx, cacheVa
     return [resKey, i];
 };
 
+/**
+ * @param {idk} time
+ */
+
 AnimationCurve.prototype.evalSTEP = function (time) {
     if (!this.animKeys || this.animKeys.length === 0)
         return null;
@@ -706,6 +884,12 @@ AnimationCurve.prototype.evalSTEP = function (time) {
     resKey.time = time;
     return resKey;
 };
+
+/**
+ * @param {idk} time
+ * @param {idk} cacheKeyIdx
+ * @param {idk} cacheValue
+ */
 
 AnimationCurve.prototype.evalSTEP_cache = function (time, cacheKeyIdx, cacheValue) { //1215
     if (!this.animKeys || this.animKeys.length === 0)
@@ -739,6 +923,10 @@ AnimationCurve.prototype.evalSTEP_cache = function (time, cacheKeyIdx, cacheValu
     resKey.time = time;
     return [resKey, i];
 };
+
+/**
+ * @param {idk} time
+ */
 
 AnimationCurve.prototype.evalCUBIC = function (time) {
     if (!this.animKeys || this.animKeys.length === 0)
@@ -779,6 +967,12 @@ AnimationCurve.prototype.evalCUBIC = function (time) {
     }
     return null;// quaternion or combo
 };
+
+/**
+ * @param {idk} time
+ * @param {idk} cacheKeyIdx
+ * @param {idk} cacheValue
+ */
 
 AnimationCurve.prototype.evalCUBIC_cache = function (time, cacheKeyIdx, cacheValue) {//1215
     if (!this.animKeys || this.animKeys.length === 0)
@@ -844,6 +1038,10 @@ AnimationCurve.prototype.evalCUBIC_cache = function (time, cacheKeyIdx, cacheVal
     return [null, cacheKeyIdx];// quaternion or combo
 };
 
+/**
+ * @param {idk} time
+ */
+
 AnimationCurve.prototype.evalCUBICSPLINE_GLTF = function (time) {
     if (!this.animKeys || this.animKeys.length === 0)
         return null;
@@ -894,6 +1092,12 @@ AnimationCurve.prototype.evalCUBICSPLINE_GLTF = function (time) {
     return resKey;
 
 };
+
+/**
+ * @param {idk} time
+ * @param {idk} cacheKeyIdx
+ * @param {idk} cacheValue
+ */
 
 AnimationCurve.prototype.evalCUBICSPLINE_GLTF_cache = function (time, cacheKeyIdx, cacheValue) {//1215
     if (!this.animKeys || this.animKeys.length === 0)
@@ -965,6 +1169,12 @@ AnimationCurve.prototype.evalCUBICSPLINE_GLTF_cache = function (time, cacheKeyId
     return [resKey, i]; 
 };
 
+/**
+ * @param {idk} time
+ * @param {idk} cacheKeyIdx
+ * @param {idk} cacheValue
+ */
+
 AnimationCurve.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) { //1215
     if (!this.animKeys || this.animKeys.length === 0)
         return [null, cacheKeyIdx];
@@ -981,6 +1191,10 @@ AnimationCurve.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) {
     }
     return [null, cacheKeyIdx];
 };
+
+/**
+ * @param {idk} time
+ */
 
 AnimationCurve.prototype.eval = function (time) {
     if (!this.animKeys || this.animKeys.length === 0)
@@ -999,7 +1213,15 @@ AnimationCurve.prototype.eval = function (time) {
     return null;
 };
 
-// static method: tangent 1, value 1, tangent 2, value 2, proportion
+/**
+ * @param {idk} t1
+ * @param {idk} v1
+ * @param {idk} t2
+ * @param {idk} v2
+ * @param {idk} p
+ * @summary static method: tangent 1, value 1, tangent 2, value 2, proportion
+ */
+
 AnimationCurve.cubicHermite = function (t1, v1, t2, v2, p) {
     // basis
     var p2 = p * p;
@@ -1013,7 +1235,17 @@ AnimationCurve.cubicHermite = function (t1, v1, t2, v2, p) {
     return v1 * h0 + v2 * h1 + t1 * h2 + t2 * h3;
 };
 
-// static: only for num or vec
+/**
+ * @param {idk} key0
+ * @param {idk} key1
+ * @param {idk} key2
+ * @param {idk} key3
+ * @param {idk} time
+ * @param {idk} tension
+ * @param {idk} cacheValue
+ * @summary static: only for num or vec
+ */
+
 AnimationCurve.cubicCardinal = function (key0, key1, key2, key3, time, tension, cacheValue) {//1215
     var m1, m2;
 
@@ -1065,10 +1297,19 @@ AnimationCurve.cubicCardinal = function (key0, key1, key2, key3, time, tension, 
 // * e.g.: for an "walking" clip of a character, at time 1s, AnimationClipSnapshot corresponds to
 // *       evaluated keyables that makes a arm-swing pose
 // *===============================================================================================================
-var AnimationClipSnapshot = function AnimationClipSnapshot() {
+
+/**
+ * @constructor
+ */
+
+var AnimationClipSnapshot = function () {
     this.curveKeyable = {};// curveKeyable[curveName]=keyable
     this.curveNames = [];
 };
+
+/**
+ * @param {idk} shot
+ */
 
 AnimationClipSnapshot.prototype.copy = function (shot) {
     if (!shot)
@@ -1083,12 +1324,19 @@ AnimationClipSnapshot.prototype.copy = function (shot) {
     }
     return this;
 };
+
 AnimationClipSnapshot.prototype.clone = function () {
     var cloned = new AnimationClipSnapshot().copy(this);
     return cloned;
 };
 
-// static function: linear blending
+/**
+ * @param {idk} shot1
+ * @param {idk} shot2
+ * @param {idk} p
+ * @summary static function: linear blending
+ */
+
 AnimationClipSnapshot.linearBlend = function (shot1, shot2, p) {
     if (!shot1 || !shot2)
         return null;
@@ -1111,7 +1359,14 @@ AnimationClipSnapshot.linearBlend = function (shot1, shot2, p) {
     return resShot;
 };
 
-// static function: linear blending except for step curve
+/**
+ * @param {idk} shot1
+ * @param {idk} shot2
+ * @param {idk} p
+ * @param {idk} animCurveMap
+ * @summary static function: linear blending except for step curve
+ */
+
 AnimationClipSnapshot.linearBlendExceptStep = function (shot1, shot2, p, animCurveMap) {
     if (!shot1 || !shot2)
         return null;
@@ -1148,7 +1403,13 @@ AnimationClipSnapshot.linearBlendExceptStep = function (shot1, shot2, p, animCur
 // * e.g.:   for an animation clip of a character, name = "walk"
 // *       each joint has one curve with keys on timeline, thus animCurves stores curves of all joints
 // *===============================================================================================================
-var AnimationClip = function AnimationClip(root) {
+
+/**
+ * @constructor
+ * @param {idk} root
+ */
+
+var AnimationClip = function (root) {
     AnimationClip.count ++;
     this.name = "clip" + AnimationClip.count.toString();
     this.duration = 0;
@@ -1190,6 +1451,10 @@ Object.defineProperty(AnimationClip.prototype, 'bySpeed', {
     }
 });
 
+/**
+ * @param {idk} clip
+ */
+
 AnimationClip.prototype.copy = function (clip) {
     this.name = clip.name;
     this.duration = clip.duration;
@@ -1218,13 +1483,30 @@ AnimationClip.prototype.updateDuration = function () {
     }
 };
 
+/**
+ * @param {idk} time
+ * @param {idk} fadeDir
+ * @param {idk} fadeBegTime
+ * @param {idk} fadeEndTime
+ * @param {idk} fadeTime
+ */
+
 AnimationClip.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndTime, fadeTime) {
     this.session.showAt(time, fadeDir, fadeBegTime, fadeEndTime, fadeTime);
 };
 
+/**
+ * @param {idk} snapshot
+ * @param {idk} p
+ */
+
 AnimationClip.prototype.blendToTarget = function (snapshot, p) {
     this.session.blendToTarget(snapshot, p);
 };
+
+/**
+ * @param {idk} snapshot
+ */
 
 AnimationClip.prototype.updateToTarget = function (snapshot) {
     this.session.updateToTarget(snapshot);
@@ -1268,19 +1550,37 @@ AnimationClip.prototype.resume = function () {
     this.session.resume();
 };
 
+/**
+ * @param {idk} duration
+ */
+
 AnimationClip.prototype.fadeIn = function (duration) {
     this.session.fadeIn(duration, this);
 };
 
+/**
+ * @param {idk} duration
+ */
+
 AnimationClip.prototype.fadeOut = function (duration) {
     this.session.fadeOut(duration);
 };
+
+/**
+ * @param {idk} toClip
+ * @param {idk} duration
+ */
 
 AnimationClip.prototype.fadeTo = function (toClip, duration) {
     this.session.fadeTo(toClip, duration);
 };
 
 // curve related
+
+/**
+ * @param {idk} curve
+ */
+
 AnimationClip.prototype.addCurve = function (curve) {
     if (curve && curve.name) {
         this.animCurves.push(curve);
@@ -1289,6 +1589,10 @@ AnimationClip.prototype.addCurve = function (curve) {
             this.duration = curve.duration;
     }
 };
+
+/**
+ * @param {idk} name
+ */
 
 AnimationClip.prototype.removeCurve = function (name) {
     if (name) {
@@ -1313,11 +1617,26 @@ AnimationClip.prototype.removeAllCurves = function () {
 
 
 // events related
+
+/**
+ * @param {idk} name
+ * @param {idk} time
+ * @param {idk} fnCallback
+ * @param {idk} context
+ * @param {idk} parameter
+ */
+
 AnimationClip.prototype.on = function (name, time, fnCallback, context, parameter) {
     if (this.session)
         this.session.on(name, time, fnCallback, context, parameter);
     return this;
 };
+
+/**
+ * @param {idk} name
+ * @param {idk} time
+ * @param {idk} fnCallback
+ */
 
 AnimationClip.prototype.off = function (name, time, fnCallback) {
     if (this.session)
@@ -1332,6 +1651,12 @@ AnimationClip.prototype.removeAllEvents = function () {
 };
 
 // clip related
+
+/**
+ * @param {idk} tmBeg
+ * @param {idk} tmEnd
+ */
+
 AnimationClip.prototype.getSubClip = function (tmBeg, tmEnd) {
     var subClip = new AnimationClip();
     subClip.name = this.name + "_sub";
@@ -1345,6 +1670,12 @@ AnimationClip.prototype.getSubClip = function (tmBeg, tmEnd) {
 
     return subClip;
 };
+
+/**
+ * @param {idk} time
+ * @param {idk} cacheKeyIdx
+ * @param {idk} cacheValue
+ */
 
 AnimationClip.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) {//1226
     if (!cacheValue)
@@ -1369,7 +1700,12 @@ AnimationClip.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) {/
     return [snapshot, cacheKeyIdx];
 };
 
-// take a snapshot of clip at this moment 
+// take a snapshot of clip at this moment
+
+/**
+ * @param {idk} time
+ */
+
 AnimationClip.prototype.eval = function (time) {
     var snapshot = new AnimationClipSnapshot();
     snapshot.time = time;
@@ -1382,6 +1718,10 @@ AnimationClip.prototype.eval = function (time) {
     }
     return snapshot;
 };
+
+/**
+ * @param {idk} root
+ */
 
 AnimationClip.prototype.constructFromRoot = function (root) {
     if (!root)
@@ -1441,6 +1781,11 @@ AnimationClip.prototype.constructFromRoot = function (root) {
 //         newTarget.vScale = NS / AS = vScale * NS / RS;
 //
 */
+
+/**
+ * @param {idk} root
+ */
+
 AnimationClip.prototype.transferToRoot = function (root) {
     var dictTarget = {};
     AnimationTarget.constructTargetNodes(root, null, dictTarget);// contains localScale information
@@ -1494,6 +1839,10 @@ AnimationClip.prototype.removeEmptyCurves = function () {
     }
 };
 
+/**
+ * @param {idk} type
+ */
+
 AnimationClip.prototype.setInterpolationType = function (type) {
     for (var i = 0, len = this.animCurves.length; i < len; i++) {
         var curve = this.animCurves[i];
@@ -1506,7 +1855,17 @@ AnimationClip.prototype.setInterpolationType = function (type) {
 // *===============================================================================================================
 // * class AnimationEvent:
 // *===============================================================================================================
-var AnimationEvent = function AnimationEvent(name, time, fnCallback, context, parameter) {
+
+/**
+ * @constructor
+ * @param {idk} name 
+ * @param {idk} time 
+ * @param {idk} fnCallback 
+ * @param {idk} context 
+ * @param {idk} parameter 
+ */
+
+var AnimationEvent = function (name, time, fnCallback, context, parameter) {
     this.name = name;
     this.triggerTime = time;
     this.fnCallback = fnCallback;
@@ -1529,7 +1888,14 @@ AnimationEvent.prototype.invoke = function () {
 //                           AnimationSession is the runtime play of curve/clip
 //                           one clip can be played by multiple AnimationSession simultaneously
 // *===============================================================================================================
-var AnimationSession = function AnimationSession(playable, targets) {
+
+/**
+ * @constructor
+ * @param {idk} playable 
+ * @param {AnimationTarget[]} targets
+ */
+
+var AnimationSession = function (playable, targets) {
     this._cacheKeyIdx;//integer if playable is curve, object {} if playable is clip
     this._cacheValue;//1215, keyable if playable is curve, snapshot if playable is clip, all pre allocated
     this._cacheBlendValues = {};//1226
@@ -1617,6 +1983,10 @@ var AnimationSession = function AnimationSession(playable, targets) {
 
 AnimationSession.app = null;
 
+/**
+ * @param {idk} playable
+ */
+
 AnimationSession._allocatePlayableCache = function(playable) {
     if (!playable)
         return null;
@@ -1703,6 +2073,13 @@ AnimationSession.prototype.clone = function () {
 };
 
 // blend related==========================================================
+
+/**
+ * @param {idk} blendValue
+ * @param {idk} weight
+ * @param {idk} curveName
+ */
+
 AnimationSession.prototype.setBlend = function (blendValue, weight, curveName){
     if (blendValue instanceof AnimationClip){
         if (!curveName || curveName === "")
@@ -1730,6 +2107,10 @@ AnimationSession.prototype.setBlend = function (blendValue, weight, curveName){
     this._cacheBlendValues[curveName] = null;//1226, null if blendable is not animationclip
 };
 
+/**
+ * @param {idk} curveName
+ */
+
 AnimationSession.prototype.unsetBlend = function (curveName) {
     if (!curveName || curveName === "")
         curveName = "__default__";
@@ -1743,6 +2124,15 @@ AnimationSession.prototype.unsetBlend = function (curveName) {
 };
 
 // events related
+
+/**
+ * @param {idk} name
+ * @param {idk} time
+ * @param {idk} fnCallback
+ * @param {idk} context
+ * @param {idk} parameter
+ */
+
 AnimationSession.prototype.on = function (name, time, fnCallback, context, parameter) {
     if (!name || !fnCallback)
         return;
@@ -1759,6 +2149,12 @@ AnimationSession.prototype.on = function (name, time, fnCallback, context, param
     else
         this.animEvents.splice(pos, 0, event);
 };
+
+/**
+ * @param {idk} name
+ * @param {idk} time
+ * @param {idk} fnCallback
+ */
 
 AnimationSession.prototype.off = function (name, time, fnCallback) {
     var pos = 0;
@@ -1780,6 +2176,10 @@ AnimationSession.prototype.removeAllEvents = function () {
     this.animEvents = [];
 };
 
+/**
+ * @param {idk} name
+ */
+
 AnimationSession.prototype.invokeByName = function (name) {
     for (var i = 0; i < this.animEvents.length; i ++) {
         if (this.animEvents[i] && this.animEvents[i].name === name) {
@@ -1787,6 +2187,10 @@ AnimationSession.prototype.invokeByName = function (name) {
         }
     }
 };
+
+/**
+ * @param {idk} time
+ */
 
 AnimationSession.prototype.invokeByTime = function (time) {
     for (var i = 0; i < this.animEvents.length; i ++) {
@@ -1801,6 +2205,11 @@ AnimationSession.prototype.invokeByTime = function (time) {
 
     }
 };
+
+/**
+ * @param {idk} input
+ * @param {idk} p
+ */
 
 AnimationSession.prototype.blendToTarget = function (input, p) {
     var i, j;
@@ -1859,6 +2268,10 @@ AnimationSession.prototype.blendToTarget = function (input, p) {
     }
 };
 
+/**
+ * @param {idk} input
+ */
+
 AnimationSession.prototype.updateToTarget = function (input) {
     var i, j;
     var cname, ctargets;
@@ -1894,6 +2307,14 @@ AnimationSession.prototype.updateToTarget = function (input) {
         }
     }
 };
+
+/**
+ * @param {idk} time
+ * @param {idk} fadeDir
+ * @param {idk} fadeBegTime
+ * @param {idk} fadeEndTime
+ * @param {idk} fadeTime
+ */
 
 AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndTime, fadeTime) {
     var i, p;
@@ -1936,6 +2357,11 @@ AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEn
         this.blendToTarget(input, p);
     }
 };
+
+/**
+ * @param {idk} playable
+ * @param {idk} animTargets
+ */
 
 AnimationSession.prototype.play = function (playable, animTargets) {
     var i;
@@ -2007,6 +2433,10 @@ AnimationSession.prototype.resume = function () {
     }
 };
 
+/**
+ * @param {idk} duration
+ */
+
 AnimationSession.prototype.fadeOut = function (duration) {
     if (this.fadeDir === 0) // fade out from normal playing session
         this.fadeSpeed = 1;
@@ -2023,6 +2453,11 @@ AnimationSession.prototype.fadeOut = function (duration) {
     this.fadeEndTime = this.fadeBegTime + duration;
     this.fadeDir = -1;
 };
+
+/**
+ * @param {idk} duration
+ * @param {idk} playable
+ */
 
 AnimationSession.prototype.fadeIn = function (duration, playable) {
     if (this.isPlaying) {
@@ -2044,12 +2479,21 @@ AnimationSession.prototype.fadeIn = function (duration, playable) {
     this.play(playable);
 };
 
+/**
+ * @param {idk} playable
+ * @param {idk} duration
+ */
+
 AnimationSession.prototype.fadeTo = function (playable, duration) {
     this.fadeOut(duration);
     var session = new AnimationSession();
     session.fadeIn(duration, playable);
     return session;
 };
+
+/**
+ * @param {idk} duration
+ */
 
 AnimationSession.prototype.fadeToSelf = function (duration) {
     var session = this.clone();
@@ -2085,11 +2529,19 @@ AnimationComponent.prototype.getCurrentClip = function () {
     return this.animClipsMap[this.curClip];
 };
 
+/**
+ * @param {idk} index
+ */
+
 AnimationComponent.prototype.clipAt = function (index) {
     if (this.animClips.length <= index)
         return null;
     return this.animClips[index];
 };
+
+/**
+ * @param {idk} clip
+ */
 
 AnimationComponent.prototype.addClip = function (clip) {
     if (clip && clip.name) {
@@ -2097,6 +2549,10 @@ AnimationComponent.prototype.addClip = function (clip) {
         this.animClipsMap[clip.name] = clip;
     }
 };
+
+/**
+ * @param {idk} name
+ */
 
 AnimationComponent.prototype.removeClip = function (name) {
     var clip = this.animClipsMap[name];
@@ -2111,6 +2567,10 @@ AnimationComponent.prototype.removeClip = function (name) {
     if (this.curClip === name)
         this.curClip = "";
 };
+
+/**
+ * @param {idk} name
+ */
 
 AnimationComponent.prototype.playClip = function (name) {
     var clip = this.animClipsMap[name];
@@ -2127,6 +2587,11 @@ AnimationComponent.prototype.stopClip = function () {
         this.curClip = "";
     }
 };
+
+/**
+ * @param {idk} name
+ * @param {idk} duration
+ */
 
 AnimationComponent.prototype.crossFadeToClip = function (name, duration) {
     var fromClip = this.animClipsMap[this.curClip];
@@ -2147,11 +2612,22 @@ AnimationComponent.prototype.crossFadeToClip = function (name, duration) {
 
 
 // blend related
+
+/**
+ * @param {idk} blendValue
+ * @param {idk} weight
+ * @param {idk} curveName
+ */
+
 AnimationComponent.prototype.setBlend = function (blendValue, weight, curveName) {
     var curClip = this.getCurrentClip();
     if (curClip && curClip.session)
         curClip.session.setBlend(blendValue, weight, curveName);
 };
+
+/**
+ * @param {idk} curveName
+ */
 
 AnimationComponent.prototype.unsetBlend = function (curveName) {
     var curClip = this.getCurrentClip();
@@ -2164,6 +2640,10 @@ AnimationComponent.prototype.unsetBlend = function (curveName) {
 AnimationComponent.prototype.getCurrentSession = function () {
     return this.animSessions[this.curClip];
 };
+
+/**
+ * @param {idk} name
+ */
 
 AnimationComponent.prototype.playSession = function (name) {
     var session = this.animSessions[name];
@@ -2180,6 +2660,11 @@ AnimationComponent.prototype.stopSession = function () {
         this.curClip = "";
     }
 };
+
+/**
+ * @param {idk} name
+ * @param {idk} duration
+ */
 
 AnimationComponent.prototype.crossFadeToSession = function (name, duration) {
     var fromSession = this.animSessions[this.curClip];
@@ -2198,6 +2683,12 @@ AnimationComponent.prototype.crossFadeToSession = function (name, duration) {
     }
 };
 
+/**
+ * @param {idk} blendValue
+ * @param {idk} weight
+ * @param {idk} curveName
+ */
+
 AnimationComponent.prototype.setBlendSession = function (blendValue, weight, curveName) {
     var curSession = this.animSessions[this.curClip];
     if (curSession) {
@@ -2205,12 +2696,20 @@ AnimationComponent.prototype.setBlendSession = function (blendValue, weight, cur
     }
 };
 
+/**
+ * @param {idk} curveName
+ */
+
 AnimationComponent.prototype.unsetBlendSession = function (curveName) {
     var curSession = this.animSessions[this.curClip];
     if (curSession) {
         curSession.unsetBlend(curveName);
     }
 };
+
+/**
+ * @param {idk} substr
+ */
 
 AnimationComponent.prototype.playSubstring = function (substr) {
     var n = this.animClips.length;

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -11,7 +11,7 @@ var AnimationKeyableType = { NUM: 0, VEC: 1, QUAT: 2 };
  * @constructor
  * @param {AnimationKeyableType} [type]
  * @param {number} [time]
- * @param {SingleDOF} [value]
+ * @param {BlendValue} [value]
  */
 
 var AnimationKeyable = function (type, time, value) {
@@ -21,7 +21,7 @@ var AnimationKeyable = function (type, time, value) {
 /**
  * @param {AnimationKeyableType} [type]
  * @param {number} [time]
- * @param {SingleDOF} [value]
+ * @param {BlendValue} [value]
  */
 
 AnimationKeyable.prototype.init = function (type, time, value) {
@@ -72,7 +72,7 @@ AnimationKeyable.prototype.clone = function () {
  */
 
 AnimationKeyable.sum = function (keyable1, keyable2) {
-    if (!keyable1 || !keyable2 || keyable1.type != keyable2)
+    if (!keyable1 || !keyable2 || keyable1.type != keyable2.type)
         return null;
 
     var resKeyable = new AnimationKeyable(keyable1.type);
@@ -95,7 +95,7 @@ AnimationKeyable.sum = function (keyable1, keyable2) {
  */
 
 AnimationKeyable.minus = function (keyable1, keyable2) {
-    if (!keyable1 || !keyable2 || keyable1.type != keyable2)
+    if (!keyable1 || !keyable2 || keyable1.type != keyable2.type)
         return null;
 
     var resKeyable = new AnimationKeyable(keyable1.type);
@@ -219,9 +219,9 @@ AnimationKeyable.linearBlendValue = function (value1, value2, p) {
 // *===============================================================================================================
 /**
  * @constructor
- * @param {idk} targetNode
- * @param {idk} [targetPath]
- * @param {idk} [targetProp]
+ * @param {pc.GraphNode} targetNode
+ * @param {string} [targetPath]
+ * @param {string} [targetProp]
  */
 var AnimationTarget = function (targetNode, targetPath, targetProp) {
     this.targetNode = targetNode;
@@ -260,8 +260,8 @@ AnimationTarget.prototype.clone = function () {
 };
 
 /**
- * @param {idk} value
- * @param {idk} p
+ * @param {pc.Vec3 | number} value
+ * @param {number} p
  * @summary based on current target[path]'s value, blend in value by p
  */
 
@@ -326,7 +326,7 @@ AnimationTarget.prototype.blendToTarget = function (value, p) {
 };
 
 /**
- * @param {idk} value
+ * @param {pc.Vec3 | number} value
  */
 
 AnimationTarget.prototype.updateToTarget = function (value) {
@@ -400,7 +400,7 @@ AnimationTarget.constructTargetNodes = function (root, vec3Scale, output) {
 
 // static function
 /**
- * @param {idk} node
+ * @param {pc.GraphNode} node
  */
 AnimationTarget.getLocalScale = function (node) {
     if (!node)
@@ -507,9 +507,9 @@ AnimationCurve.prototype.clone = function () {
 };
 
 /**
- * @param {idk} targetNode
- * @param {idk} targetPath
- * @param {idk} targetProp
+ * @param {pc.GraphNode} targetNode
+ * @param {string} targetPath
+ * @param {string} targetProp
  */
 
 AnimationCurve.prototype.addTarget = function (targetNode, targetPath, targetProp) {
@@ -518,9 +518,9 @@ AnimationCurve.prototype.addTarget = function (targetNode, targetPath, targetPro
 };
 
 /**
- * @param {idk} targetNode
- * @param {idk} targetPath
- * @param {idk} [targetProp]
+ * @param {pc.GraphNode} targetNode
+ * @param {string} targetPath
+ * @param {string} [targetProp]
  */
 
 AnimationCurve.prototype.setTarget = function (targetNode, targetPath, targetProp) {
@@ -573,11 +573,11 @@ AnimationCurve.prototype.getAnimTargets = function () {
 
 // events related
 /**
- * @param {idk} name
- * @param {idk} time
- * @param {idk} fnCallback
- * @param {idk} context
- * @param {idk} parameter
+ * @param {string} name
+ * @param {number} time
+ * @param {AnimationEventCallback} fnCallback
+ * @param {any} context
+ * @param {any} parameter
  */
 
 AnimationCurve.prototype.on = function (name, time, fnCallback, context, parameter) {
@@ -587,9 +587,9 @@ AnimationCurve.prototype.on = function (name, time, fnCallback, context, paramet
 };
 
 /**
- * @param {idk} name
- * @param {idk} time
- * @param {idk} fnCallback
+ * @param {string} name
+ * @param {number} time
+ * @param {AnimationEventCallback} fnCallback
  */
 
 AnimationCurve.prototype.off = function (name, time, fnCallback) {
@@ -605,7 +605,7 @@ AnimationCurve.prototype.removeAllEvents = function () {
 };
 
 /**
- * @param {idk} duration
+ * @param {number} duration
  */
 
 AnimationCurve.prototype.fadeIn = function (duration) {
@@ -613,7 +613,7 @@ AnimationCurve.prototype.fadeIn = function (duration) {
 };
 
 /**
- * @param {idk} duration
+ * @param {number} duration
  */
 
 AnimationCurve.prototype.fadeOut = function (duration) {
@@ -637,11 +637,11 @@ AnimationCurve.prototype.pause = function () {
 };
 
 /**
- * @param {idk} time
- * @param {idk} fadeDir
- * @param {idk} fadeBegTime
- * @param {idk} fadeEndTime
- * @param {idk} fadeTime
+ * @param {number} time
+ * @param {number} fadeDir
+ * @param {number} fadeBegTime
+ * @param {number} fadeEndTime
+ * @param {number} fadeTime
  */
 
 AnimationCurve.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndTime, fadeTime) {
@@ -649,7 +649,7 @@ AnimationCurve.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndT
 };
 
 /**
- * @param {idk} animKeys
+ * @param {AnimationKeyable[]} animKeys
  */
 
 AnimationCurve.prototype.setAnimKeys = function (animKeys) {
@@ -657,9 +657,9 @@ AnimationCurve.prototype.setAnimKeys = function (animKeys) {
 };
 
 /**
- * @param {idk} type
- * @param {idk} time
- * @param {idk} value
+ * @param {AnimationCurveType} type
+ * @param {number} time
+ * @param {SingleDOF} value
  */
 
 AnimationCurve.prototype.insertKey = function (type, time, value) {
@@ -691,7 +691,7 @@ AnimationCurve.prototype.insertKey = function (type, time, value) {
 
 // 10/15
 /**
- * @param {idk} keyable
+ * @param {AnimationKeyable} keyable
  */
 AnimationCurve.prototype.insertKeyable = function (keyable) {
     if (!keyable || this.keyableType != keyable.type)
@@ -720,7 +720,7 @@ AnimationCurve.prototype.insertKeyable = function (keyable) {
 };
 
 /**
- * @param {idk} index
+ * @param {number} index
  */
 
 AnimationCurve.prototype.removeKey = function (index) {
@@ -1375,7 +1375,7 @@ AnimationClipSnapshot.linearBlend = function (shot1, shot2, p) {
  * @param {AnimationClipSnapshot} shot1
  * @param {AnimationClipSnapshot} shot2
  * @param {number} p
- * @param {idk} animCurveMap
+ * @param {AnimationCurveMap} animCurveMap
  * @summary static function: linear blending except for step curve
  */
 
@@ -1418,7 +1418,7 @@ AnimationClipSnapshot.linearBlendExceptStep = function (shot1, shot2, p, animCur
 
 /**
  * @constructor
- * @param {idk} [root]
+ * @param {pc.GraphNode} [root]
  */
 
 var AnimationClip = function (root) {
@@ -1464,7 +1464,7 @@ Object.defineProperty(AnimationClip.prototype, 'bySpeed', {
 });
 
 /**
- * @param {idk} clip
+ * @param {AnimationClip} clip
  */
 
 AnimationClip.prototype.copy = function (clip) {
@@ -1496,11 +1496,11 @@ AnimationClip.prototype.updateDuration = function () {
 };
 
 /**
- * @param {idk} time
- * @param {idk} fadeDir
- * @param {idk} fadeBegTime
- * @param {idk} fadeEndTime
- * @param {idk} fadeTime
+ * @param {number} time
+ * @param {number} fadeDir
+ * @param {number} fadeBegTime
+ * @param {number} fadeEndTime
+ * @param {number} fadeTime
  */
 
 AnimationClip.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndTime, fadeTime) {
@@ -1508,8 +1508,8 @@ AnimationClip.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndTi
 };
 
 /**
- * @param {idk} snapshot
- * @param {idk} p
+ * @param {AnimationClipSnapshot} snapshot
+ * @param {number} p
  */
 
 AnimationClip.prototype.blendToTarget = function (snapshot, p) {
@@ -1517,7 +1517,7 @@ AnimationClip.prototype.blendToTarget = function (snapshot, p) {
 };
 
 /**
- * @param {idk} snapshot
+ * @param {AnimationClipSnapshot} snapshot
  */
 
 AnimationClip.prototype.updateToTarget = function (snapshot) {
@@ -1567,7 +1567,7 @@ AnimationClip.prototype.resume = function () {
 };
 
 /**
- * @param {idk} duration
+ * @param {number} duration
  */
 
 AnimationClip.prototype.fadeIn = function (duration) {
@@ -1575,7 +1575,7 @@ AnimationClip.prototype.fadeIn = function (duration) {
 };
 
 /**
- * @param {idk} duration
+ * @param {number} duration
  */
 
 AnimationClip.prototype.fadeOut = function (duration) {
@@ -1583,8 +1583,8 @@ AnimationClip.prototype.fadeOut = function (duration) {
 };
 
 /**
- * @param {idk} toClip
- * @param {idk} duration
+ * @param {AnimationClip} toClip
+ * @param {number} duration
  */
 
 AnimationClip.prototype.fadeTo = function (toClip, duration) {
@@ -1594,7 +1594,7 @@ AnimationClip.prototype.fadeTo = function (toClip, duration) {
 // curve related
 
 /**
- * @param {idk} curve
+ * @param {AnimationCurve} curve
  */
 
 AnimationClip.prototype.addCurve = function (curve) {
@@ -1607,7 +1607,7 @@ AnimationClip.prototype.addCurve = function (curve) {
 };
 
 /**
- * @param {idk} name
+ * @param {string} name
  */
 
 AnimationClip.prototype.removeCurve = function (name) {
@@ -1635,11 +1635,11 @@ AnimationClip.prototype.removeAllCurves = function () {
 // events related
 
 /**
- * @param {idk} name
- * @param {idk} time
- * @param {idk} fnCallback
- * @param {idk} context
- * @param {idk} parameter
+ * @param {string} name
+ * @param {number} time
+ * @param {AnimationEventCallback} fnCallback
+ * @param {any} context
+ * @param {any} parameter
  */
 
 AnimationClip.prototype.on = function (name, time, fnCallback, context, parameter) {
@@ -1649,9 +1649,9 @@ AnimationClip.prototype.on = function (name, time, fnCallback, context, paramete
 };
 
 /**
- * @param {idk} name
- * @param {idk} time
- * @param {idk} fnCallback
+ * @param {string} name
+ * @param {number} time
+ * @param {AnimationEventCallback} fnCallback
  */
 
 AnimationClip.prototype.off = function (name, time, fnCallback) {
@@ -1689,7 +1689,7 @@ AnimationClip.prototype.getSubClip = function (tmBeg, tmEnd) {
 
 /**
  * @param {number} time
- * @param {idk} cacheKeyIdx
+ * @param {AnimationCacheKey} cacheKeyIdx
  * @param {AnimationClipSnapshot} cacheValue
  */
 
@@ -1736,7 +1736,7 @@ AnimationClip.prototype.eval = function (time) {
 };
 
 /**
- * @param {idk} root
+ * @param {pc.GraphNode} root
  */
 
 AnimationClip.prototype.constructFromRoot = function (root) {
@@ -1799,7 +1799,7 @@ AnimationClip.prototype.constructFromRoot = function (root) {
 */
 
 /**
- * @param {idk} root
+ * @param {pc.GraphNode} root
  */
 
 AnimationClip.prototype.transferToRoot = function (root) {
@@ -1856,7 +1856,7 @@ AnimationClip.prototype.removeEmptyCurves = function () {
 };
 
 /**
- * @param {idk} type
+ * @param {AnimationCurveType} type
  */
 
 AnimationClip.prototype.setInterpolationType = function (type) {
@@ -1872,9 +1872,9 @@ AnimationClip.prototype.setInterpolationType = function (type) {
  * @constructor
  * @param {string} name
  * @param {number} time
- * @param {idk} fnCallback
- * @param {idk} context
- * @param {idk} parameter
+ * @param {AnimationEventCallback} fnCallback
+ * @param {any} context
+ * @param {any} parameter
  */
 
 var AnimationEvent_ = function (name, time, fnCallback, context, parameter) {
@@ -1963,7 +1963,7 @@ var AnimationSession = function (playable, targets) {
 
     // ontimer function for playback
     var self = this;
-    this.onTimer = function (dt) {
+    this.onTimer = function (/**@type {number} */dt) {
         self.curTime += (self.bySpeed * dt);
         self.accTime += (self.bySpeed * dt);
 
@@ -2151,11 +2151,11 @@ AnimationSession.prototype.unsetBlend = function (curveName) {
 // events related
 
 /**
- * @param {idk} name
- * @param {idk} time
- * @param {idk} fnCallback
- * @param {idk} context
- * @param {idk} parameter
+ * @param {string} name
+ * @param {number} time
+ * @param {AnimationEventCallback} fnCallback
+ * @param {any} context
+ * @param {any} parameter
  */
 
 AnimationSession.prototype.on = function (name, time, fnCallback, context, parameter) {
@@ -2178,7 +2178,7 @@ AnimationSession.prototype.on = function (name, time, fnCallback, context, param
 /**
  * @param {string} name
  * @param {number} time
- * @param {idk} fnCallback
+ * @param {AnimationEventCallback} fnCallback
  */
 
 AnimationSession.prototype.off = function (name, time, fnCallback) {
@@ -2334,11 +2334,11 @@ AnimationSession.prototype.updateToTarget = function (input) {
 };
 
 /**
- * @param {idk} time
- * @param {idk} fadeDir
- * @param {idk} fadeBegTime
- * @param {idk} fadeEndTime
- * @param {idk} fadeTime
+ * @param {number} time
+ * @param {number} fadeDir
+ * @param {number} fadeBegTime
+ * @param {number} fadeEndTime
+ * @param {number} fadeTime
  */
 
 AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEndTime, fadeTime) {
@@ -2459,7 +2459,7 @@ AnimationSession.prototype.resume = function () {
 };
 
 /**
- * @param {idk} duration
+ * @param {number} duration
  */
 
 AnimationSession.prototype.fadeOut = function (duration) {
@@ -2480,7 +2480,7 @@ AnimationSession.prototype.fadeOut = function (duration) {
 };
 
 /**
- * @param {idk} duration
+ * @param {number} duration
  * @param {Playable} [playable]
  */
 
@@ -2505,8 +2505,8 @@ AnimationSession.prototype.fadeIn = function (duration, playable) {
 };
 
 /**
- * @param {idk} playable
- * @param {idk} duration
+ * @param {Playable} playable
+ * @param {number} duration
  */
 
 AnimationSession.prototype.fadeTo = function (playable, duration) {
@@ -2517,7 +2517,7 @@ AnimationSession.prototype.fadeTo = function (playable, duration) {
 };
 
 /**
- * @param {idk} duration
+ * @param {number} duration
  */
 
 AnimationSession.prototype.fadeToSelf = function (duration) {
@@ -2624,7 +2624,7 @@ AnimationComponent.prototype.stopClip = function () {
 
 /**
  * @param {string} name
- * @param {idk} duration
+ * @param {number} duration
  */
 
 AnimationComponent.prototype.crossFadeToClip = function (name, duration) {
@@ -2648,9 +2648,9 @@ AnimationComponent.prototype.crossFadeToClip = function (name, duration) {
 // blend related
 
 /**
- * @param {idk} blendValue
- * @param {idk} weight
- * @param {idk} curveName
+ * @param {BlendValue} blendValue
+ * @param {number} weight
+ * @param {string} curveName
  */
 
 AnimationComponent.prototype.setBlend = function (blendValue, weight, curveName) {
@@ -2660,7 +2660,7 @@ AnimationComponent.prototype.setBlend = function (blendValue, weight, curveName)
 };
 
 /**
- * @param {idk} curveName
+ * @param {string} curveName
  */
 
 AnimationComponent.prototype.unsetBlend = function (curveName) {
@@ -2718,9 +2718,9 @@ AnimationComponent.prototype.crossFadeToSession = function (name, duration) {
 };
 
 /**
- * @param {idk} blendValue
- * @param {idk} weight
- * @param {idk} curveName
+ * @param {BlendValue} blendValue
+ * @param {number} weight
+ * @param {string} curveName
  */
 
 AnimationComponent.prototype.setBlendSession = function (blendValue, weight, curveName) {
@@ -2731,7 +2731,7 @@ AnimationComponent.prototype.setBlendSession = function (blendValue, weight, cur
 };
 
 /**
- * @param {idk} curveName
+ * @param {string} curveName
  */
 
 AnimationComponent.prototype.unsetBlendSession = function (curveName) {
@@ -2742,7 +2742,7 @@ AnimationComponent.prototype.unsetBlendSession = function (curveName) {
 };
 
 /**
- * @param {idk} substr
+ * @param {string} substr
  */
 
 AnimationComponent.prototype.playSubstring = function (substr) {

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -2,13 +2,16 @@
 // * class AnimationKeyable
 // *
 // *===============================================================================================================
+/**
+ * @enum {number}
+ */
 var AnimationKeyableType = { NUM: 0, VEC: 1, QUAT: 2 };
 
 /**
  * @constructor
- * @param {idk} type 
- * @param {idk} [time]
- * @param {idk} [value]
+ * @param {AnimationKeyableType} [type]
+ * @param {number} [time]
+ * @param {SingleDOF} [value]
  */
 
 var AnimationKeyable = function (type, time, value) {
@@ -16,9 +19,9 @@ var AnimationKeyable = function (type, time, value) {
 };
 
 /**
- * @param {idk} type
- * @param {idk} time
- * @param {idk} value
+ * @param {AnimationKeyableType} [type]
+ * @param {number} [time]
+ * @param {SingleDOF} [value]
  */
 
 AnimationKeyable.prototype.init = function (type, time, value) {
@@ -37,7 +40,7 @@ AnimationKeyable.prototype.init = function (type, time, value) {
 };
 
 /**
- * @param {idk} keyable
+ * @param {AnimationKeyable} keyable
  */
 
 AnimationKeyable.prototype.copy = function (keyable) {
@@ -61,8 +64,8 @@ AnimationKeyable.prototype.clone = function () {
 };
 
 /**
- * @param {idk} keyable1
- * @param {idk} keyable2
+ * @param {AnimationKeyable} keyable1
+ * @param {AnimationKeyable} keyable2
  * @summary
  * static function for lack of overloaded operator
  * return keyable1 + keyable2
@@ -86,8 +89,8 @@ AnimationKeyable.sum = function (keyable1, keyable2) {
 };
 
 /**
- * @param {idk} keyable1
- * @param {idk} keyable2
+ * @param {AnimationKeyable} keyable1
+ * @param {AnimationKeyable} keyable2
  * @summary return keyable1 - keyable2
  */
 
@@ -109,8 +112,8 @@ AnimationKeyable.minus = function (keyable1, keyable2) {
 };
 
 /**
- * @param {idk} keyable
- * @param {idk} coeff
+ * @param {AnimationKeyable} keyable
+ * @param {number} coeff
  * @summary return keyable * coeff
  */
 
@@ -133,8 +136,8 @@ AnimationKeyable.mul = function (keyable, coeff) {
 };
 
 /**
- * @param {idk} keyable
- * @param {idk} coeff
+ * @param {AnimationKeyable} keyable
+ * @param {number} coeff
  */
 // return keyable / coeff
 AnimationKeyable.div = function (keyable, coeff) {
@@ -145,10 +148,10 @@ AnimationKeyable.div = function (keyable, coeff) {
 };
 
 /**
- * @param {idk} keyable1
- * @param {idk} keyable2
- * @param {idk} p
- * @param {idk} cacheValue
+ * @param {AnimationKeyable} keyable1
+ * @param {AnimationKeyable} keyable2
+ * @param {number} p
+ * @param {AnimationKeyable} [cacheValue]
  */
 
 AnimationKeyable.linearBlend = function (keyable1, keyable2, p, cacheValue) {
@@ -181,9 +184,9 @@ AnimationKeyable.linearBlend = function (keyable1, keyable2, p, cacheValue) {
 };
 
 /**
- * @param {idk} value1
- * @param {idk} value2
- * @param {idk} p
+ * @param {SingleDOF} value1
+ * @param {SingleDOF} value2
+ * @param {number} p
  */
 
 AnimationKeyable.linearBlendValue = function (value1, value2, p) {
@@ -217,8 +220,8 @@ AnimationKeyable.linearBlendValue = function (value1, value2, p) {
 /**
  * @constructor
  * @param {idk} targetNode
- * @param {idk} targetPath
- * @param {idk} targetProp
+ * @param {idk} [targetPath]
+ * @param {idk} [targetProp]
  */
 var AnimationTarget = function (targetNode, targetPath, targetProp) {
     this.targetNode = targetNode;
@@ -725,7 +728,7 @@ AnimationCurve.prototype.removeAllKeys = function () {
 };
 
 /**
- * @param {idk} time
+ * @param {number} time
  */
 
 AnimationCurve.prototype.shiftKeyTime = function (time) {
@@ -734,8 +737,8 @@ AnimationCurve.prototype.shiftKeyTime = function (time) {
 };
 
 /**
- * @param {idk} tmBeg
- * @param {idk} tmEnd
+ * @param {number} tmBeg
+ * @param {number} tmEnd
  */
 
 AnimationCurve.prototype.getSubCurve = function (tmBeg, tmEnd) {
@@ -768,7 +771,7 @@ AnimationCurve.prototype.getSubCurve = function (tmBeg, tmEnd) {
 };
 
 /**
- * @param {idk} time
+ * @param {number} time
  */
 
 AnimationCurve.prototype.evalLINEAR = function (time) {
@@ -806,9 +809,9 @@ AnimationCurve.prototype.evalLINEAR = function (time) {
 };
 
 /**
- * @param {idk} time
- * @param {idk} cacheKeyIdx
- * @param {idk} cacheValue
+ * @param {number} time
+ * @param {number} cacheKeyIdx
+ * @param {AnimationKeyable} cacheValue
  */
 
 AnimationCurve.prototype.evalLINEAR_cache = function (time, cacheKeyIdx, cacheValue) { //1215
@@ -865,7 +868,7 @@ AnimationCurve.prototype.evalLINEAR_cache = function (time, cacheKeyIdx, cacheVa
 };
 
 /**
- * @param {idk} time
+ * @param {number} time
  */
 
 AnimationCurve.prototype.evalSTEP = function (time) {
@@ -886,9 +889,9 @@ AnimationCurve.prototype.evalSTEP = function (time) {
 };
 
 /**
- * @param {idk} time
- * @param {idk} cacheKeyIdx
- * @param {idk} cacheValue
+ * @param {number} time
+ * @param {number} cacheKeyIdx
+ * @param {AnimationKeyable} cacheValue
  */
 
 AnimationCurve.prototype.evalSTEP_cache = function (time, cacheKeyIdx, cacheValue) { //1215
@@ -925,7 +928,7 @@ AnimationCurve.prototype.evalSTEP_cache = function (time, cacheKeyIdx, cacheValu
 };
 
 /**
- * @param {idk} time
+ * @param {number} time
  */
 
 AnimationCurve.prototype.evalCUBIC = function (time) {
@@ -969,9 +972,9 @@ AnimationCurve.prototype.evalCUBIC = function (time) {
 };
 
 /**
- * @param {idk} time
- * @param {idk} cacheKeyIdx
- * @param {idk} cacheValue
+ * @param {number} time
+ * @param {number} cacheKeyIdx
+ * @param {AnimationKeyable} cacheValue
  */
 
 AnimationCurve.prototype.evalCUBIC_cache = function (time, cacheKeyIdx, cacheValue) {//1215
@@ -1039,7 +1042,7 @@ AnimationCurve.prototype.evalCUBIC_cache = function (time, cacheKeyIdx, cacheVal
 };
 
 /**
- * @param {idk} time
+ * @param {number} time
  */
 
 AnimationCurve.prototype.evalCUBICSPLINE_GLTF = function (time) {
@@ -1094,9 +1097,9 @@ AnimationCurve.prototype.evalCUBICSPLINE_GLTF = function (time) {
 };
 
 /**
- * @param {idk} time
- * @param {idk} cacheKeyIdx
- * @param {idk} cacheValue
+ * @param {number} time
+ * @param {number} cacheKeyIdx
+ * @param {AnimationKeyable} cacheValue
  */
 
 AnimationCurve.prototype.evalCUBICSPLINE_GLTF_cache = function (time, cacheKeyIdx, cacheValue) {//1215
@@ -1170,9 +1173,9 @@ AnimationCurve.prototype.evalCUBICSPLINE_GLTF_cache = function (time, cacheKeyId
 };
 
 /**
- * @param {idk} time
- * @param {idk} cacheKeyIdx
- * @param {idk} cacheValue
+ * @param {number} time
+ * @param {number} cacheKeyIdx
+ * @param {AnimationKeyable} cacheValue
  */
 
 AnimationCurve.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) { //1215
@@ -1193,7 +1196,7 @@ AnimationCurve.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) {
 };
 
 /**
- * @param {idk} time
+ * @param {number} time
  */
 
 AnimationCurve.prototype.eval = function (time) {
@@ -1214,11 +1217,11 @@ AnimationCurve.prototype.eval = function (time) {
 };
 
 /**
- * @param {idk} t1
- * @param {idk} v1
- * @param {idk} t2
- * @param {idk} v2
- * @param {idk} p
+ * @param {number} t1
+ * @param {number} v1
+ * @param {number} t2
+ * @param {number} v2
+ * @param {number} p
  * @summary static method: tangent 1, value 1, tangent 2, value 2, proportion
  */
 
@@ -1236,13 +1239,13 @@ AnimationCurve.cubicHermite = function (t1, v1, t2, v2, p) {
 };
 
 /**
- * @param {idk} key0
- * @param {idk} key1
- * @param {idk} key2
- * @param {idk} key3
- * @param {idk} time
- * @param {idk} tension
- * @param {idk} cacheValue
+ * @param {AnimationKeyable} key0
+ * @param {AnimationKeyable} key1
+ * @param {AnimationKeyable} key2
+ * @param {AnimationKeyable} key3
+ * @param {number} time
+ * @param {number} tension
+ * @param {AnimationKeyable} [cacheValue]
  * @summary static: only for num or vec
  */
 
@@ -1308,7 +1311,7 @@ var AnimationClipSnapshot = function () {
 };
 
 /**
- * @param {idk} shot
+ * @param {AnimationClipSnapshot} shot
  */
 
 AnimationClipSnapshot.prototype.copy = function (shot) {
@@ -1331,9 +1334,9 @@ AnimationClipSnapshot.prototype.clone = function () {
 };
 
 /**
- * @param {idk} shot1
- * @param {idk} shot2
- * @param {idk} p
+ * @param {AnimationClipSnapshot} shot1
+ * @param {AnimationClipSnapshot} shot2
+ * @param {number} p
  * @summary static function: linear blending
  */
 
@@ -1360,9 +1363,9 @@ AnimationClipSnapshot.linearBlend = function (shot1, shot2, p) {
 };
 
 /**
- * @param {idk} shot1
- * @param {idk} shot2
- * @param {idk} p
+ * @param {AnimationClipSnapshot} shot1
+ * @param {AnimationClipSnapshot} shot2
+ * @param {number} p
  * @param {idk} animCurveMap
  * @summary static function: linear blending except for step curve
  */
@@ -1406,7 +1409,7 @@ AnimationClipSnapshot.linearBlendExceptStep = function (shot1, shot2, p, animCur
 
 /**
  * @constructor
- * @param {idk} root
+ * @param {idk} [root]
  */
 
 var AnimationClip = function (root) {
@@ -1653,8 +1656,8 @@ AnimationClip.prototype.removeAllEvents = function () {
 // clip related
 
 /**
- * @param {idk} tmBeg
- * @param {idk} tmEnd
+ * @param {number} tmBeg
+ * @param {number} tmEnd
  */
 
 AnimationClip.prototype.getSubClip = function (tmBeg, tmEnd) {
@@ -1672,9 +1675,9 @@ AnimationClip.prototype.getSubClip = function (tmBeg, tmEnd) {
 };
 
 /**
- * @param {idk} time
+ * @param {number} time
  * @param {idk} cacheKeyIdx
- * @param {idk} cacheValue
+ * @param {AnimationClipSnapshot} cacheValue
  */
 
 AnimationClip.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) {//1226
@@ -1703,7 +1706,7 @@ AnimationClip.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) {/
 // take a snapshot of clip at this moment
 
 /**
- * @param {idk} time
+ * @param {number} [time]
  */
 
 AnimationClip.prototype.eval = function (time) {
@@ -1858,8 +1861,8 @@ AnimationClip.prototype.setInterpolationType = function (type) {
 
 /**
  * @constructor
- * @param {idk} name 
- * @param {idk} time 
+ * @param {string} name 
+ * @param {number} time 
  * @param {idk} fnCallback 
  * @param {idk} context 
  * @param {idk} parameter 
@@ -1881,6 +1884,16 @@ AnimationEvent_.prototype.invoke = function () {
         this.triggered = true;
     }
 };
+
+AnimationEvent_.prototype.clone = function () {
+    return new AnimationEvent_(
+        this.name,
+        this.triggerTime,
+        this.fnCallback,
+        this.context,
+        this.parameter
+    );
+}
 
 // *===============================================================================================================
 // * class AnimationSession: playback/runtime related thing
@@ -2108,7 +2121,7 @@ AnimationSession.prototype.setBlend = function (blendValue, weight, curveName){
 };
 
 /**
- * @param {idk} curveName
+ * @param {string} curveName
  */
 
 AnimationSession.prototype.unsetBlend = function (curveName) {
@@ -2151,8 +2164,8 @@ AnimationSession.prototype.on = function (name, time, fnCallback, context, param
 };
 
 /**
- * @param {idk} name
- * @param {idk} time
+ * @param {string} name
+ * @param {number} time
  * @param {idk} fnCallback
  */
 
@@ -2177,7 +2190,7 @@ AnimationSession.prototype.removeAllEvents = function () {
 };
 
 /**
- * @param {idk} name
+ * @param {string} name
  */
 
 AnimationSession.prototype.invokeByName = function (name) {
@@ -2189,7 +2202,7 @@ AnimationSession.prototype.invokeByName = function (name) {
 };
 
 /**
- * @param {idk} time
+ * @param {number} time
  */
 
 AnimationSession.prototype.invokeByTime = function (time) {
@@ -2207,8 +2220,8 @@ AnimationSession.prototype.invokeByTime = function (time) {
 };
 
 /**
- * @param {idk} input
- * @param {idk} p
+ * @param {AnimationInput} input
+ * @param {number} p
  */
 
 AnimationSession.prototype.blendToTarget = function (input, p) {
@@ -2269,7 +2282,7 @@ AnimationSession.prototype.blendToTarget = function (input, p) {
 };
 
 /**
- * @param {idk} input
+ * @param {AnimationInput} input
  */
 
 AnimationSession.prototype.updateToTarget = function (input) {
@@ -2359,8 +2372,8 @@ AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEn
 };
 
 /**
- * @param {idk} playable
- * @param {idk} animTargets
+ * @param {Playable} playable
+ * @param {AnimationTargetsMap} [animTargets]
  */
 
 AnimationSession.prototype.play = function (playable, animTargets) {
@@ -2456,7 +2469,7 @@ AnimationSession.prototype.fadeOut = function (duration) {
 
 /**
  * @param {idk} duration
- * @param {idk} playable
+ * @param {Playable} [playable]
  */
 
 AnimationSession.prototype.fadeIn = function (duration, playable) {

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -1891,8 +1891,8 @@ AnimationEvent.prototype.invoke = function () {
 
 /**
  * @constructor
- * @param {idk} playable 
- * @param {AnimationTarget[]} targets
+ * @param {Playable} playable 
+ * @param {AnimationTargetsMap} targets
  */
 
 var AnimationSession = function (playable, targets) {

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -22,6 +22,7 @@ var AnimationKeyable = function (type, time, value) {
  * @param {AnimationKeyableType} [type]
  * @param {number} [time]
  * @param {BlendValue} [value]
+ * @returns {AnimationKeyable}
  */
 
 AnimationKeyable.prototype.init = function (type, time, value) {
@@ -41,6 +42,7 @@ AnimationKeyable.prototype.init = function (type, time, value) {
 
 /**
  * @param {AnimationKeyable} keyable
+ * @returns {AnimationKeyable}
  */
 
 AnimationKeyable.prototype.copy = function (keyable) {
@@ -66,6 +68,7 @@ AnimationKeyable.prototype.clone = function () {
 /**
  * @param {AnimationKeyable} keyable1
  * @param {AnimationKeyable} keyable2
+ * @returns {AnimationKeyable}
  * @summary
  * static function for lack of overloaded operator
  * return keyable1 + keyable2
@@ -91,6 +94,7 @@ AnimationKeyable.sum = function (keyable1, keyable2) {
 /**
  * @param {AnimationKeyable} keyable1
  * @param {AnimationKeyable} keyable2
+ * @returns {AnimationKeyable}
  * @summary return keyable1 - keyable2
  */
 
@@ -114,6 +118,7 @@ AnimationKeyable.minus = function (keyable1, keyable2) {
 /**
  * @param {AnimationKeyable} keyable
  * @param {number} coeff
+ * @returns {AnimationKeyable}
  * @summary return keyable * coeff
  */
 
@@ -138,6 +143,7 @@ AnimationKeyable.mul = function (keyable, coeff) {
 /**
  * @param {AnimationKeyable} keyable
  * @param {number} coeff
+ * @returns {AnimationKeyable}
  */
 // return keyable / coeff
 AnimationKeyable.div = function (keyable, coeff) {
@@ -152,6 +158,7 @@ AnimationKeyable.div = function (keyable, coeff) {
  * @param {AnimationKeyable} keyable2
  * @param {number} p
  * @param {AnimationKeyable} [cacheValue]
+ * @returns {AnimationKeyable}
  */
 
 AnimationKeyable.linearBlend = function (keyable1, keyable2, p, cacheValue) {
@@ -379,9 +386,9 @@ AnimationTarget.prototype.updateToTarget = function (value) {
 
 // static function
 /**
- * @param {idk} root
- * @param {idk} vec3Scale
- * @param {idk} output
+ * @param {pc.GraphNode} root
+ * @param {pc.Vec3} vec3Scale
+ * @param {object} output
  */
 AnimationTarget.constructTargetNodes = function (root, vec3Scale, output) {
     if (!root)
@@ -401,6 +408,7 @@ AnimationTarget.constructTargetNodes = function (root, vec3Scale, output) {
 // static function
 /**
  * @param {pc.GraphNode} node
+ * @returns {pc.Vec3}
  */
 AnimationTarget.getLocalScale = function (node) {
     if (!node)
@@ -598,6 +606,10 @@ AnimationCurve.prototype.off = function (name, time, fnCallback) {
     return this;
 };
 
+/**
+ * @returns {AnimationCurve}
+ */
+
 AnimationCurve.prototype.removeAllEvents = function () {
     if (this.session)
         this.session.removeAllEvents();
@@ -781,6 +793,7 @@ AnimationCurve.prototype.getSubCurve = function (tmBeg, tmEnd) {
 
 /**
  * @param {number} time
+ * @returns {AnimationKeyable}
  */
 
 AnimationCurve.prototype.evalLINEAR = function (time) {
@@ -821,6 +834,7 @@ AnimationCurve.prototype.evalLINEAR = function (time) {
  * @param {number} time
  * @param {number} cacheKeyIdx
  * @param {AnimationKeyable} cacheValue
+ * @returns {Tuple_AnimationKeyable_number}
  */
 
 AnimationCurve.prototype.evalLINEAR_cache = function (time, cacheKeyIdx, cacheValue) { //1215
@@ -878,6 +892,7 @@ AnimationCurve.prototype.evalLINEAR_cache = function (time, cacheKeyIdx, cacheVa
 
 /**
  * @param {number} time
+ * @returns {AnimationKeyable}
  */
 
 AnimationCurve.prototype.evalSTEP = function (time) {
@@ -901,6 +916,7 @@ AnimationCurve.prototype.evalSTEP = function (time) {
  * @param {number} time
  * @param {number} cacheKeyIdx
  * @param {AnimationKeyable} cacheValue
+ * @returns {Tuple_AnimationKeyable_number}
  */
 
 AnimationCurve.prototype.evalSTEP_cache = function (time, cacheKeyIdx, cacheValue) { //1215
@@ -938,6 +954,7 @@ AnimationCurve.prototype.evalSTEP_cache = function (time, cacheKeyIdx, cacheValu
 
 /**
  * @param {number} time
+ * @returns {AnimationKeyable}
  */
 
 AnimationCurve.prototype.evalCUBIC = function (time) {
@@ -984,6 +1001,7 @@ AnimationCurve.prototype.evalCUBIC = function (time) {
  * @param {number} time
  * @param {number} cacheKeyIdx
  * @param {AnimationKeyable} cacheValue
+ * @returns {Tuple_AnimationKeyable_number}
  */
 
 AnimationCurve.prototype.evalCUBIC_cache = function (time, cacheKeyIdx, cacheValue) {//1215
@@ -1052,6 +1070,7 @@ AnimationCurve.prototype.evalCUBIC_cache = function (time, cacheKeyIdx, cacheVal
 
 /**
  * @param {number} time
+ * @returns {AnimationKeyable}
  */
 
 AnimationCurve.prototype.evalCUBICSPLINE_GLTF = function (time) {
@@ -1109,6 +1128,7 @@ AnimationCurve.prototype.evalCUBICSPLINE_GLTF = function (time) {
  * @param {number} time
  * @param {number} cacheKeyIdx
  * @param {AnimationKeyable} cacheValue
+ * @returns {Tuple_AnimationKeyable_number}
  */
 
 AnimationCurve.prototype.evalCUBICSPLINE_GLTF_cache = function (time, cacheKeyIdx, cacheValue) {//1215
@@ -1185,6 +1205,7 @@ AnimationCurve.prototype.evalCUBICSPLINE_GLTF_cache = function (time, cacheKeyId
  * @param {number} time
  * @param {number} cacheKeyIdx
  * @param {AnimationKeyable} cacheValue
+ * @returns {Tuple_AnimationKeyable_number}
  */
 
 AnimationCurve.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) { //1215
@@ -1206,6 +1227,7 @@ AnimationCurve.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) {
 
 /**
  * @param {number} time
+ * @returns {AnimationKeyable}
  */
 
 AnimationCurve.prototype.eval = function (time) {
@@ -1231,6 +1253,7 @@ AnimationCurve.prototype.eval = function (time) {
  * @param {number} t2
  * @param {number} v2
  * @param {number} p
+ * @returns {number}
  * @summary static method: tangent 1, value 1, tangent 2, value 2, proportion
  */
 
@@ -1255,6 +1278,7 @@ AnimationCurve.cubicHermite = function (t1, v1, t2, v2, p) {
  * @param {number} time
  * @param {number} tension
  * @param {AnimationKeyable} [cacheValue]
+ * @returns {AnimationKeyable}
  * @summary static: only for num or vec
  */
 
@@ -1346,6 +1370,7 @@ AnimationClipSnapshot.prototype.clone = function () {
  * @param {AnimationClipSnapshot} shot1
  * @param {AnimationClipSnapshot} shot2
  * @param {number} p
+ * @returns {AnimationClipSnapshot}
  * @summary static function: linear blending
  */
 
@@ -1376,6 +1401,7 @@ AnimationClipSnapshot.linearBlend = function (shot1, shot2, p) {
  * @param {AnimationClipSnapshot} shot2
  * @param {number} p
  * @param {AnimationCurveMap} animCurveMap
+ * @returns {AnimationClipSnapshot}
  * @summary static function: linear blending except for step curve
  */
 
@@ -1465,6 +1491,7 @@ Object.defineProperty(AnimationClip.prototype, 'bySpeed', {
 
 /**
  * @param {AnimationClip} clip
+ * @returns {AnimationClip}
  */
 
 AnimationClip.prototype.copy = function (clip) {
@@ -1671,6 +1698,7 @@ AnimationClip.prototype.removeAllEvents = function () {
 /**
  * @param {number} tmBeg
  * @param {number} tmEnd
+ * @returns {AnimationClip}
  */
 
 AnimationClip.prototype.getSubClip = function (tmBeg, tmEnd) {
@@ -1689,8 +1717,9 @@ AnimationClip.prototype.getSubClip = function (tmBeg, tmEnd) {
 
 /**
  * @param {number} time
- * @param {AnimationCacheKey} cacheKeyIdx
+ * @param {MapStringToNumber} cacheKeyIdx
  * @param {AnimationClipSnapshot} cacheValue
+ * @returns {Tuple_AnimationClipSnapshot_MapStringToNumber}
  */
 
 AnimationClip.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) {//1226
@@ -1720,6 +1749,7 @@ AnimationClip.prototype.eval_cache = function (time, cacheKeyIdx, cacheValue) {/
 
 /**
  * @param {number} [time]
+ * @returns {AnimationClipSnapshot}
  */
 
 AnimationClip.prototype.eval = function (time) {
@@ -2010,6 +2040,7 @@ AnimationSession.app = null;
 
 /**
  * @param {Playable} playable
+ * @returns {AnimationKeyable | AnimationClipSnapshot}
  */
 
 AnimationSession._allocatePlayableCache = function(playable) {
@@ -2384,8 +2415,9 @@ AnimationSession.prototype.showAt = function (time, fadeDir, fadeBegTime, fadeEn
 };
 
 /**
- * @param {Playable} playable
+ * @param {Playable} [playable]
  * @param {AnimationTargetsMap} [animTargets]
+ * @returns {AnimationSession}
  */
 
 AnimationSession.prototype.play = function (playable, animTargets) {
@@ -2551,6 +2583,10 @@ var AnimationComponent = function () {
     this.animSessions = {};
 };
 
+/**
+ * @returns {number}
+ */
+
 AnimationComponent.prototype.clipCount = function () {
     return this.animClips.length;
 };
@@ -2565,6 +2601,7 @@ AnimationComponent.prototype.getCurrentClip = function () {
 
 /**
  * @param {number} index
+ * @returns {AnimationClip}
  */
 
 AnimationComponent.prototype.clipAt = function (index) {

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -1923,7 +1923,7 @@ AnimationClip.prototype.setInterpolationType = function (type) {
  * @param {any} parameter
  */
 
-var AnimationEvent_ = function (name, time, fnCallback, context, parameter) {
+var AnimationEvent = function (name, time, fnCallback, context, parameter) {
     this.name = name;
     this.triggerTime = time;
     this.fnCallback = fnCallback;
@@ -1933,7 +1933,7 @@ var AnimationEvent_ = function (name, time, fnCallback, context, parameter) {
     this.triggered = false;
 };
 
-AnimationEvent_.prototype.invoke = function () {
+AnimationEvent.prototype.invoke = function () {
     if (this.fnCallback) {
         this.fnCallback.call(this.context, this.parameter);
         this.triggered = true;
@@ -1941,8 +1941,8 @@ AnimationEvent_.prototype.invoke = function () {
 };
 
 /*
-// note: used in line 2083, but undefined... never used so far
-pcAnimationEvent.prototype.clone = function () {
+// note: used in line 2127, but undefined... never used so far
+AnimationEvent.prototype.clone = function () {
     return new pcAnimationEvent(
         this.name,
         this.triggerTime,
@@ -2208,7 +2208,7 @@ AnimationSession.prototype.on = function (name, time, fnCallback, context, param
     if (!name || !fnCallback)
         return;
 
-    var event = new AnimationEvent_(name, time, fnCallback, context, parameter);
+    var event = new AnimationEvent(name, time, fnCallback, context, parameter);
     var pos = 0;
     for (; pos < this.animEvents.length; pos ++) {
         if (this.animEvents[pos].triggerTime > time)

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -7,8 +7,8 @@ var AnimationKeyableType = { NUM: 0, VEC: 1, QUAT: 2 };
 /**
  * @constructor
  * @param {idk} type 
- * @param {idk} time 
- * @param {idk} value 
+ * @param {idk} [time]
+ * @param {idk} [value]
  */
 
 var AnimationKeyable = function (type, time, value) {
@@ -1865,7 +1865,7 @@ AnimationClip.prototype.setInterpolationType = function (type) {
  * @param {idk} parameter 
  */
 
-var AnimationEvent = function (name, time, fnCallback, context, parameter) {
+var AnimationEvent_ = function (name, time, fnCallback, context, parameter) {
     this.name = name;
     this.triggerTime = time;
     this.fnCallback = fnCallback;
@@ -1875,7 +1875,7 @@ var AnimationEvent = function (name, time, fnCallback, context, parameter) {
     this.triggered = false;
 };
 
-AnimationEvent.prototype.invoke = function () {
+AnimationEvent_.prototype.invoke = function () {
     if (this.fnCallback) {
         this.fnCallback.call(this.context, this.parameter);
         this.triggered = true;
@@ -1891,8 +1891,8 @@ AnimationEvent.prototype.invoke = function () {
 
 /**
  * @constructor
- * @param {Playable} playable 
- * @param {AnimationTargetsMap} targets
+ * @param {Playable} [playable]
+ * @param {AnimationTargetsMap} [targets]
  */
 
 var AnimationSession = function (playable, targets) {
@@ -1984,7 +1984,7 @@ var AnimationSession = function (playable, targets) {
 AnimationSession.app = null;
 
 /**
- * @param {idk} playable
+ * @param {Playable} playable
  */
 
 AnimationSession._allocatePlayableCache = function(playable) {
@@ -2031,7 +2031,7 @@ AnimationSession.prototype.clone = function () {
     // fading
     cloned.fadeBegTime = this.fadeBegTime;
     cloned.fadeEndTime = this.fadeEndTime;
-    cloned.fadtTime = this.fadeTime;
+    cloned.fadeTime = this.fadeTime;
     cloned.fadeDir = this.fadeDir;// 1 is in, -1 is out
     cloned.fadeSpeed = this.fadeSpeed;
 
@@ -2075,9 +2075,9 @@ AnimationSession.prototype.clone = function () {
 // blend related==========================================================
 
 /**
- * @param {idk} blendValue
- * @param {idk} weight
- * @param {idk} curveName
+ * @param {BlendValue} blendValue
+ * @param {number} weight
+ * @param {string} curveName
  */
 
 AnimationSession.prototype.setBlend = function (blendValue, weight, curveName){
@@ -2137,7 +2137,7 @@ AnimationSession.prototype.on = function (name, time, fnCallback, context, param
     if (!name || !fnCallback)
         return;
 
-    var event = new AnimationEvent(name, time, fnCallback, context, parameter);
+    var event = new AnimationEvent_(name, time, fnCallback, context, parameter);
     var pos = 0;
     for (; pos < this.animEvents.length; pos ++) {
         if (this.animEvents[pos].triggerTime > time)
@@ -2511,7 +2511,12 @@ AnimationSession.prototype.fadeToSelf = function (duration) {
 // *       animClips: dictionary type, query animation clips animClips[clipName]
 // *
 // *===============================================================================================================
-var AnimationComponent = function AnimationComponent() {
+
+/**
+ * @constructor
+ */
+
+var AnimationComponent = function () {
     this.name = "";
     this.animClipsMap = {}; // make it a map, easy to query clip by name
     this.animClips = [];
@@ -2525,12 +2530,16 @@ AnimationComponent.prototype.clipCount = function () {
     return this.animClips.length;
 };
 
+/**
+ * @returns {AnimationClip}
+ */
+
 AnimationComponent.prototype.getCurrentClip = function () {
     return this.animClipsMap[this.curClip];
 };
 
 /**
- * @param {idk} index
+ * @param {number} index
  */
 
 AnimationComponent.prototype.clipAt = function (index) {
@@ -2540,7 +2549,7 @@ AnimationComponent.prototype.clipAt = function (index) {
 };
 
 /**
- * @param {idk} clip
+ * @param {AnimationClip} clip
  */
 
 AnimationComponent.prototype.addClip = function (clip) {
@@ -2551,7 +2560,7 @@ AnimationComponent.prototype.addClip = function (clip) {
 };
 
 /**
- * @param {idk} name
+ * @param {string} name
  */
 
 AnimationComponent.prototype.removeClip = function (name) {
@@ -2569,7 +2578,7 @@ AnimationComponent.prototype.removeClip = function (name) {
 };
 
 /**
- * @param {idk} name
+ * @param {string} name
  */
 
 AnimationComponent.prototype.playClip = function (name) {
@@ -2589,7 +2598,7 @@ AnimationComponent.prototype.stopClip = function () {
 };
 
 /**
- * @param {idk} name
+ * @param {string} name
  * @param {idk} duration
  */
 
@@ -2642,7 +2651,7 @@ AnimationComponent.prototype.getCurrentSession = function () {
 };
 
 /**
- * @param {idk} name
+ * @param {string} name
  */
 
 AnimationComponent.prototype.playSession = function (name) {
@@ -2662,8 +2671,8 @@ AnimationComponent.prototype.stopSession = function () {
 };
 
 /**
- * @param {idk} name
- * @param {idk} duration
+ * @param {string} name
+ * @param {number} duration
  */
 
 AnimationComponent.prototype.crossFadeToSession = function (name, duration) {

--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -426,6 +426,11 @@ AnimationTarget.getLocalScale = function (node) {
 // *        type: how to interpolate between keys.
 // *
 // *===============================================================================================================
+
+/**
+ * @enum {number}
+ */
+
 var AnimationCurveType = { LINEAR: 0, STEP: 1, CUBIC: 2, CUBICSPLINE_GLTF: 3 };
 
 /**
@@ -472,7 +477,7 @@ Object.defineProperty(AnimationCurve.prototype, 'bySpeed', {
 });
 
 /**
- * @param {idk} curve
+ * @param {AnimationCurve} curve
  */
 
 AnimationCurve.prototype.copy = function (curve) {
@@ -515,7 +520,7 @@ AnimationCurve.prototype.addTarget = function (targetNode, targetPath, targetPro
 /**
  * @param {idk} targetNode
  * @param {idk} targetPath
- * @param {idk} targetProp
+ * @param {idk} [targetProp]
  */
 
 AnimationCurve.prototype.setTarget = function (targetNode, targetPath, targetProp) {
@@ -539,8 +544,8 @@ AnimationCurve.prototype.resetSession = function () {
 };
 
 /**
- * @param {idk} keyable
- * @param {idk} p
+ * @param {AnimationKeyable} keyable
+ * @param {number} p
  */
 
 AnimationCurve.prototype.blendToTarget = function (keyable, p) {
@@ -548,7 +553,7 @@ AnimationCurve.prototype.blendToTarget = function (keyable, p) {
 };
 
 /**
- * @param {idk} keyable
+ * @param {AnimationKeyable} keyable
  */
 
 AnimationCurve.prototype.updateToTarget = function (keyable) {
@@ -556,7 +561,11 @@ AnimationCurve.prototype.updateToTarget = function (keyable) {
 };
 
 // this.animTargets wrapped in object, with curve name
+/**
+ * @returns {AnimationTargetsMap}
+ */
 AnimationCurve.prototype.getAnimTargets = function () {
+    /** @type {AnimationTargetsMap} */
     var result = {};
     result[this.name] = this.animTargets;// an array []
     return result;
@@ -1516,7 +1525,11 @@ AnimationClip.prototype.updateToTarget = function (snapshot) {
 };
 
 // a dictionary: retrieve animTargets with curve name
+/**
+ * @returns {AnimationTargetsMap}
+ */
 AnimationClip.prototype.getAnimTargets = function () {
+    /** @type {AnimationTargetsMap} */
     var animTargets = {};
     for (var i = 0, len = this.animCurves.length; i < len; i++) {
         var curve = this.animCurves[i];
@@ -1855,17 +1868,13 @@ AnimationClip.prototype.setInterpolationType = function (type) {
     }
 };
 
-// *===============================================================================================================
-// * class AnimationEvent:
-// *===============================================================================================================
-
 /**
  * @constructor
- * @param {string} name 
- * @param {number} time 
- * @param {idk} fnCallback 
- * @param {idk} context 
- * @param {idk} parameter 
+ * @param {string} name
+ * @param {number} time
+ * @param {idk} fnCallback
+ * @param {idk} context
+ * @param {idk} parameter
  */
 
 var AnimationEvent_ = function (name, time, fnCallback, context, parameter) {
@@ -1885,8 +1894,10 @@ AnimationEvent_.prototype.invoke = function () {
     }
 };
 
-AnimationEvent_.prototype.clone = function () {
-    return new AnimationEvent_(
+/*
+// note: used in line 2083, but undefined... never used so far
+pcAnimationEvent.prototype.clone = function () {
+    return new pcAnimationEvent(
         this.name,
         this.triggerTime,
         this.fnCallback,
@@ -1894,6 +1905,7 @@ AnimationEvent_.prototype.clone = function () {
         this.parameter
     );
 }
+*/
 
 // *===============================================================================================================
 // * class AnimationSession: playback/runtime related thing

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "amd",
+        "noImplicitAny": true,
+        "removeComments": true,
+        "preserveConstEnums": true,
+        "outFile": "../../built/local/tsc.js",
+        "sourceMap": true,
+        "allowJs": true,
+        "checkJs": true
+    },
+    "include": [
+        "src/**/*",
+        "types/playcanvas/*",
+        "types/playcanvas-gltf/*"
+    ]
+}

--- a/types/playcanvas-gltf/index.d.ts
+++ b/types/playcanvas-gltf/index.d.ts
@@ -48,9 +48,6 @@ declare type Blendable = AnimationKeyable | BlendValue;
 // }
 declare type MapStringToNumber = {[curvenum: string]: number};
 
-declare type Tuple_AnimationKeyable_number = [AnimationKeyable, number];
-declare type Tuple_AnimationClipSnapshot_MapStringToNumber = [AnimationClipSnapshot, MapStringToNumber];
-
 declare interface Playable {
 	animCurvesMap: AnimationCurveMap;
 	session: AnimationSession;

--- a/types/playcanvas-gltf/index.d.ts
+++ b/types/playcanvas-gltf/index.d.ts
@@ -17,7 +17,7 @@ declare interface AnimationKeyable {
 	normalize(): any;
 }
 
-interface AnimationEventCallback {
+declare interface AnimationEventCallback {
 	(context: any, parameter: any): void
 }
 
@@ -29,28 +29,24 @@ declare interface AnimationTarget {
 	
 }
 
-type SingleDOF = number | pc.Vec2 | pc.Vec3 | pc.Vec4 | pc.Quat;
-type BlendValue = SingleDOF | Playable;
-type AnimationInput = AnimationCurve | AnimationKeyable | AnimationClip | AnimationClipSnapshot;
+declare type SingleDOF = number | pc.Vec2 | pc.Vec3 | pc.Vec4 | pc.Quat;
+declare type BlendValue = SingleDOF | Playable;
+declare type AnimationInput = AnimationCurve | AnimationKeyable | AnimationClip | AnimationClipSnapshot;
 
-/*
+// looks like: {
+// 	...
+// 	curve13: 106,
+// 	curve14: 106,
+// 	curve15: 106,
+// 	curve16: 66,
+// 	curve17: 105,
+// 	curve18: 106,
+// 	...
+// }
+declare type MapStringToNumber = {[curvenum: string]: number};
 
-the object subtype looks like:
-
-{	
-	...
-	curve13: 106,
-	curve14: 106,
-	curve15: 106,
-	curve16: 66,
-	curve17: 105,
-	curve18: 106,
-	...
-}
-
-*/
-
-type AnimationCacheKey = /*number |*/ {[curvenum: string]: number};
+declare type Tuple_AnimationKeyable_number = [AnimationKeyable, number];
+declare type Tuple_AnimationClipSnapshot_MapStringToNumber = [AnimationClipSnapshot, MapStringToNumber];
 
 declare interface Playable {
 	animCurvesMap: any;
@@ -111,9 +107,9 @@ declare interface AnimationSession {
 }
 
 declare interface AnimationComponent {
-	animClips: any;
-	animClipsMap: any;
-	animSessions: any;
+	animClips: AnimationClip[];
+	animClipsMap: {[clipname: string]: AnimationClip};
+	animSessions: {[sessionname: string]: AnimationSession};
 }
 
 declare interface AnimationTargetsMap {

--- a/types/playcanvas-gltf/index.d.ts
+++ b/types/playcanvas-gltf/index.d.ts
@@ -11,10 +11,10 @@ declare namespace pc {
 }
 
 declare interface AnimationKeyable {
-	value: any;
+	value: BlendValue;
 	outTangent: SingleDOF;
 	inTangent: SingleDOF;
-	normalize(): any;
+	normalize(): void;
 }
 
 declare interface AnimationEventCallback {
@@ -33,6 +33,8 @@ declare type SingleDOF = number | pc.Vec2 | pc.Vec3 | pc.Vec4 | pc.Quat;
 declare type BlendValue = SingleDOF | Playable;
 declare type AnimationInput = AnimationCurve | AnimationKeyable | AnimationClip | AnimationClipSnapshot;
 
+declare type Blendable = AnimationKeyable | BlendValue;
+
 // looks like: {
 // 	...
 // 	curve13: 106,
@@ -49,10 +51,10 @@ declare type Tuple_AnimationKeyable_number = [AnimationKeyable, number];
 declare type Tuple_AnimationClipSnapshot_MapStringToNumber = [AnimationClipSnapshot, MapStringToNumber];
 
 declare interface Playable {
-	animCurvesMap: any;
+	animCurvesMap: AnimationCurveMap;
 	session: AnimationSession;
-	bySpeed: any;
-	loop: any;
+	bySpeed: number;
+	loop: boolean;
 	getAnimTargets(): AnimationTargetsMap;
 	eval_cache(time: number, cacheKeyIdx: any, cacheValue: any): any;
 }
@@ -62,17 +64,16 @@ declare class AnimationCurve implements Playable {
 	type: AnimationCurveType;
 	tension: number;
 	duration: number;
-	keyableType: any;
+	keyableType: AnimationKeyableType;
 	animTargets: AnimationTarget[];
 	animKeys: AnimationKeyable[];
-	animCurvesMap: any;
+	animCurvesMap: AnimationCurveMap;
 	session: AnimationSession;
 	getAnimTargets(): AnimationTargetsMap;
 }
 
 declare class AnimationClipSnapshot {
-	curveKeyable: any;
-	value: any;
+	curveKeyable: {[curvename: string]: AnimationKeyable};
 	curveNames: string[];
 	time: number;
 }
@@ -97,13 +98,13 @@ declare class AnimationClip implements Playable {
 declare interface AnimationSession {
 	animTargets: AnimationTargetsMap;
 	_cacheKeyIdx: number | object;
-	speed: any;
-	blendables: any;
-	_cacheBlendValues: any;
-	blendWeights: any;
+	speed: number;
+	blendables: {[curveName: string]: Blendable};
+	_cacheBlendValues: {[name: string]: AnimationClipSnapshot | AnimationKeyable};
+	blendWeights: {[name: string]: Playable};
 	animEvents: AnimationEvent_[];
 	onTimer: (dt: number) => void;
-	_allocatePlayableCache(): any;
+	_allocatePlayableCache(): Playable;
 }
 
 declare interface AnimationComponent {

--- a/types/playcanvas-gltf/index.d.ts
+++ b/types/playcanvas-gltf/index.d.ts
@@ -1,10 +1,12 @@
-declare class AnimationKeyable {
+declare interface AnimationKeyable {
 	value: any;
+	outTangent: SingleDOF;
+	inTangent: SingleDOF;
 	normalize(): any;
 }
 
-declare class AnimationTarget {
-
+declare interface AnimationTarget {
+	vScale?: pc.Vec3 | number[];
 }
 
 type idk = any; // not figured out yet / todo
@@ -12,7 +14,20 @@ type SingleDOF = number | pc.Vec2 | pc.Vec3 | pc.Vec4 | pc.Quat;
 type BlendValue = SingleDOF | Playable;
 type AnimationInput = AnimationCurve | AnimationKeyable | AnimationClip | AnimationClipSnapshot;
 
-declare class AnimationCurve extends Playable {
+declare interface Playable {
+	animCurvesMap: any;
+	session: AnimationSession;
+	bySpeed: any;
+	loop: any;
+	getAnimTargets(): AnimationTargetsMap;
+	eval_cache(time: number, cacheKeyIdx: any, cacheValue: any): any;
+}
+
+declare class AnimationCurve implements Playable {
+	name: string;
+	type: AnimationCurveType;
+	tension: number;
+	duration: number;
 	keyableType: any;
 	animTargets: AnimationTarget[];
 	animKeys: AnimationKeyable[];
@@ -28,19 +43,24 @@ declare class AnimationClipSnapshot {
 	time: number;
 }
 
-declare class AnimationClip extends Playable {
+// AnimationEvent is a CSS class, so I added an underscore
+declare interface AnimationEvent_ {
+	name: string;
+	triggerTime: number;
+	fnCallback: any;
+}
+
+declare class AnimationClip implements Playable {
 	duration: number;
 	animCurves: any;
 	session: AnimationSession;
 	animCurvesMap: any;
+	root: any;
+	getAnimTargets(): AnimationTargetsMap;
 }
 
-// AnimationEvent is a CSS class, so I added an underscore
-declare interface AnimationEvent_ {
 
-}
-
-declare class AnimationSession {
+declare interface AnimationSession {
 	animTargets: AnimationTargetsMap;
 	_cacheKeyIdx: number | object;
 	speed: any;
@@ -48,6 +68,7 @@ declare class AnimationSession {
 	_cacheBlendValues: any;
 	blendWeights: any;
 	animEvents: AnimationEvent_[];
+	onTimer: any;
 	_allocatePlayableCache(): any;
 }
 
@@ -57,14 +78,6 @@ declare interface AnimationComponent {
 	animSessions: any;
 }
 
-declare interface Playable {
-	animCurvesMap: any;
-	session: AnimationSession;
-	bySpeed: any;
-	loop: any;
-	getAnimTargets(): AnimationTargetsMap;
-	eval_cache(time: number, cacheKeyIdx: any, cacheValue: any): any;
-}
 
 declare interface AnimationTargetsMap {
 	[name: string]: AnimationTarget[];

--- a/types/playcanvas-gltf/index.d.ts
+++ b/types/playcanvas-gltf/index.d.ts
@@ -1,0 +1,24 @@
+declare interface Playable {
+	getAnimTargets(): AnimationTargetsMap;
+}
+
+declare interface AnimationTargetsMap {
+	[name: string]: AnimationTarget;
+}
+
+declare class AnimationTarget {
+
+}
+
+declare class AnimationCurve extends Playable {
+
+}
+
+declare class AnimationClip {
+	duration: number;
+}
+
+declare class AnimationSession {
+	animTargets: AnimationTargetsMap;
+
+}

--- a/types/playcanvas-gltf/index.d.ts
+++ b/types/playcanvas-gltf/index.d.ts
@@ -76,8 +76,8 @@ declare class AnimationClipSnapshot {
     _cacheKeyIdx: MapStringToNumber;
 }
 
-// AnimationEvent is a CSS class, so I added an underscore
-declare interface AnimationEvent_ {
+// todo: rename AnimationEvent (name collision with CSS)
+declare interface AnimationEvent {
     name: string;
     triggerTime: number;
     fnCallback: AnimationEventCallback;
@@ -100,7 +100,7 @@ declare interface AnimationSession {
     blendables: {[curveName: string]: Blendable};
     _cacheBlendValues: {[name: string]: AnimationClipSnapshot | AnimationKeyable};
     blendWeights: {[name: string]: Playable};
-    animEvents: AnimationEvent_[];
+    animEvents: AnimationEvent[];
     onTimer: (dt: number) => void;
     _allocatePlayableCache(): Playable;
 }

--- a/types/playcanvas-gltf/index.d.ts
+++ b/types/playcanvas-gltf/index.d.ts
@@ -1,3 +1,15 @@
+
+// extend playcanvas-typings
+declare namespace pc {
+	interface Vec3 {
+		[prop: string]: any;
+	}
+	interface GraphNode {
+        name: string;
+		[prop: string]: any;
+	}
+}
+
 declare interface AnimationKeyable {
 	value: any;
 	outTangent: SingleDOF;
@@ -5,14 +17,40 @@ declare interface AnimationKeyable {
 	normalize(): any;
 }
 
-declare interface AnimationTarget {
-	vScale?: pc.Vec3 | number[];
+interface AnimationEventCallback {
+	(context: any, parameter: any): void
 }
 
-type idk = any; // not figured out yet / todo
+declare interface AnimationTarget {
+	vScale?: pc.Vec3 | number[];
+	targetNode: pc.GraphNode;
+	targetPath: string;
+	targetProp: string;
+	
+}
+
 type SingleDOF = number | pc.Vec2 | pc.Vec3 | pc.Vec4 | pc.Quat;
 type BlendValue = SingleDOF | Playable;
 type AnimationInput = AnimationCurve | AnimationKeyable | AnimationClip | AnimationClipSnapshot;
+
+/*
+
+the object subtype looks like:
+
+{	
+	...
+	curve13: 106,
+	curve14: 106,
+	curve15: 106,
+	curve16: 66,
+	curve17: 105,
+	curve18: 106,
+	...
+}
+
+*/
+
+type AnimationCacheKey = /*number |*/ {[curvenum: string]: number};
 
 declare interface Playable {
 	animCurvesMap: any;
@@ -47,18 +85,18 @@ declare class AnimationClipSnapshot {
 declare interface AnimationEvent_ {
 	name: string;
 	triggerTime: number;
-	fnCallback: any;
+	fnCallback: AnimationEventCallback;
 }
 
 declare class AnimationClip implements Playable {
+	name: string;
 	duration: number;
-	animCurves: any;
+	animCurves: AnimationCurve[];
 	session: AnimationSession;
-	animCurvesMap: any;
-	root: any;
+	animCurvesMap: AnimationCurveMap;
+	root: pc.GraphNode;
 	getAnimTargets(): AnimationTargetsMap;
 }
-
 
 declare interface AnimationSession {
 	animTargets: AnimationTargetsMap;
@@ -68,7 +106,7 @@ declare interface AnimationSession {
 	_cacheBlendValues: any;
 	blendWeights: any;
 	animEvents: AnimationEvent_[];
-	onTimer: any;
+	onTimer: (dt: number) => void;
 	_allocatePlayableCache(): any;
 }
 
@@ -78,7 +116,10 @@ declare interface AnimationComponent {
 	animSessions: any;
 }
 
-
 declare interface AnimationTargetsMap {
 	[name: string]: AnimationTarget[];
+}
+
+declare interface AnimationCurveMap {
+	[name: string]: AnimationCurve;
 }

--- a/types/playcanvas-gltf/index.d.ts
+++ b/types/playcanvas-gltf/index.d.ts
@@ -1,33 +1,32 @@
 
 // extend playcanvas-typings
 declare namespace pc {
-	interface Vec3 {
-		[prop: string]: any;
-	}
-	interface GraphNode {
+    interface Vec3 {
+        [prop: string]: any;
+    }
+    interface GraphNode {
         name: string;
-		[prop: string]: any;
-	}
+        [prop: string]: any;
+    }
 }
 
 declare interface AnimationKeyable {
-	value: BlendValue;
-	outTangent: SingleDOF;
-	inTangent: SingleDOF;
-	_cacheKeyIdx: number;
-	normalize(): void;
+    value: BlendValue;
+    outTangent: SingleDOF;
+    inTangent: SingleDOF;
+    _cacheKeyIdx: number;
+    normalize(): void;
 }
 
 declare interface AnimationEventCallback {
-	(context: any, parameter: any): void
+    (context: any, parameter: any): void
 }
 
 declare interface AnimationTarget {
-	vScale?: pc.Vec3 | number[];
-	targetNode: pc.GraphNode;
-	targetPath: string;
-	targetProp: string;
-	
+    vScale?: pc.Vec3 | number[];
+    targetNode: pc.GraphNode;
+    targetPath: string;
+    targetProp: string;
 }
 
 declare type SingleDOF = number | pc.Vec2 | pc.Vec3 | pc.Vec4 | pc.Quat;
@@ -37,85 +36,85 @@ declare type AnimationInput = AnimationCurve | AnimationKeyable | AnimationClip 
 declare type Blendable = AnimationKeyable | BlendValue;
 
 // looks like: {
-// 	...
-// 	curve13: 106,
-// 	curve14: 106,
-// 	curve15: 106,
-// 	curve16: 66,
-// 	curve17: 105,
-// 	curve18: 106,
-// 	...
+//     ...
+//     curve13: 106,
+//     curve14: 106,
+//     curve15: 106,
+//     curve16: 66,
+//     curve17: 105,
+//     curve18: 106,
+//     ...
 // }
 declare type MapStringToNumber = {[curvenum: string]: number};
 
 declare interface Playable {
-	animCurvesMap: AnimationCurveMap;
-	session: AnimationSession;
-	bySpeed: number;
-	loop: boolean;
-	getAnimTargets(): AnimationTargetsMap;
-	eval_cache(time: number, cacheKeyIdx: any, cacheValue: any): any;
+    animCurvesMap: AnimationCurveMap;
+    session: AnimationSession;
+    bySpeed: number;
+    loop: boolean;
+    getAnimTargets(): AnimationTargetsMap;
+    eval_cache(time: number, cacheKeyIdx: any, cacheValue: any): any;
 }
 
 declare class AnimationCurve implements Playable {
-	name: string;
-	type: AnimationCurveType;
-	tension: number;
-	duration: number;
-	keyableType: AnimationKeyableType;
-	animTargets: AnimationTarget[];
-	animKeys: AnimationKeyable[];
-	animCurvesMap: AnimationCurveMap;
-	session: AnimationSession;
-	getAnimTargets(): AnimationTargetsMap;
+    name: string;
+    type: AnimationCurveType;
+    tension: number;
+    duration: number;
+    keyableType: AnimationKeyableType;
+    animTargets: AnimationTarget[];
+    animKeys: AnimationKeyable[];
+    animCurvesMap: AnimationCurveMap;
+    session: AnimationSession;
+    getAnimTargets(): AnimationTargetsMap;
 }
 
 declare class AnimationClipSnapshot {
-	curveKeyable: {[curvename: string]: AnimationKeyable};
-	curveNames: string[];
-	time: number;
-	_cacheKeyIdx: MapStringToNumber;
+    curveKeyable: {[curvename: string]: AnimationKeyable};
+    curveNames: string[];
+    time: number;
+    _cacheKeyIdx: MapStringToNumber;
 }
 
 // AnimationEvent is a CSS class, so I added an underscore
 declare interface AnimationEvent_ {
-	name: string;
-	triggerTime: number;
-	fnCallback: AnimationEventCallback;
+    name: string;
+    triggerTime: number;
+    fnCallback: AnimationEventCallback;
 }
 
 declare class AnimationClip implements Playable {
-	name: string;
-	duration: number;
-	animCurves: AnimationCurve[];
-	session: AnimationSession;
-	animCurvesMap: AnimationCurveMap;
-	root: pc.GraphNode;
-	getAnimTargets(): AnimationTargetsMap;
+    name: string;
+    duration: number;
+    animCurves: AnimationCurve[];
+    session: AnimationSession;
+    animCurvesMap: AnimationCurveMap;
+    root: pc.GraphNode;
+    getAnimTargets(): AnimationTargetsMap;
 }
 
 declare interface AnimationSession {
-	animTargets: AnimationTargetsMap;
-	_cacheKeyIdx: number | object;
-	speed: number;
-	blendables: {[curveName: string]: Blendable};
-	_cacheBlendValues: {[name: string]: AnimationClipSnapshot | AnimationKeyable};
-	blendWeights: {[name: string]: Playable};
-	animEvents: AnimationEvent_[];
-	onTimer: (dt: number) => void;
-	_allocatePlayableCache(): Playable;
+    animTargets: AnimationTargetsMap;
+    _cacheKeyIdx: number | object;
+    speed: number;
+    blendables: {[curveName: string]: Blendable};
+    _cacheBlendValues: {[name: string]: AnimationClipSnapshot | AnimationKeyable};
+    blendWeights: {[name: string]: Playable};
+    animEvents: AnimationEvent_[];
+    onTimer: (dt: number) => void;
+    _allocatePlayableCache(): Playable;
 }
 
 declare interface AnimationComponent {
-	animClips: AnimationClip[];
-	animClipsMap: {[clipname: string]: AnimationClip};
-	animSessions: {[sessionname: string]: AnimationSession};
+    animClips: AnimationClip[];
+    animClipsMap: {[clipname: string]: AnimationClip};
+    animSessions: {[sessionname: string]: AnimationSession};
 }
 
 declare interface AnimationTargetsMap {
-	[name: string]: AnimationTarget[];
+    [name: string]: AnimationTarget[];
 }
 
 declare interface AnimationCurveMap {
-	[name: string]: AnimationCurve;
+    [name: string]: AnimationCurve;
 }

--- a/types/playcanvas-gltf/index.d.ts
+++ b/types/playcanvas-gltf/index.d.ts
@@ -1,24 +1,53 @@
-declare interface Playable {
-	getAnimTargets(): AnimationTargetsMap;
-}
+declare class AnimationKeyable {
 
-declare interface AnimationTargetsMap {
-	[name: string]: AnimationTarget;
 }
 
 declare class AnimationTarget {
 
 }
 
-declare class AnimationCurve extends Playable {
+type SingleDOF = number | pc.Vec3 | pc.Vec4;
 
+type BlendValue = SingleDOF | Playable;
+
+declare class AnimationCurve extends Playable {
+	keyableType: any;
 }
 
-declare class AnimationClip {
+declare class AnimationClipSnapshot {
+	curveKeyable: any;
+}
+
+declare class AnimationClip extends Playable {
 	duration: number;
+	animCurves: any;
+	session: AnimationSession;
+}
+
+declare interface AnimationEvent_ {
+
 }
 
 declare class AnimationSession {
 	animTargets: AnimationTargetsMap;
+	_cacheKeyIdx: number | object;
+	speed: any;
+	blendables: any;
+	_cacheBlendValues: any;
+	blendWeights: any;
+	_allocatePlayableCache(): any;
+}
 
+declare interface AnimationComponent {
+	animClips: any;
+	animClipsMap: any;
+	animSessions: any;
+}
+
+declare interface Playable {
+	getAnimTargets(): AnimationTargetsMap;
+}
+
+declare interface AnimationTargetsMap {
+	[name: string]: AnimationTarget[];
 }

--- a/types/playcanvas-gltf/index.d.ts
+++ b/types/playcanvas-gltf/index.d.ts
@@ -1,29 +1,41 @@
 declare class AnimationKeyable {
-
+	value: any;
+	normalize(): any;
 }
 
 declare class AnimationTarget {
 
 }
 
-type SingleDOF = number | pc.Vec3 | pc.Vec4;
-
+type idk = any; // not figured out yet / todo
+type SingleDOF = number | pc.Vec2 | pc.Vec3 | pc.Vec4 | pc.Quat;
 type BlendValue = SingleDOF | Playable;
+type AnimationInput = AnimationCurve | AnimationKeyable | AnimationClip | AnimationClipSnapshot;
 
 declare class AnimationCurve extends Playable {
 	keyableType: any;
+	animTargets: AnimationTarget[];
+	animKeys: AnimationKeyable[];
+	animCurvesMap: any;
+	session: AnimationSession;
+	getAnimTargets(): AnimationTargetsMap;
 }
 
 declare class AnimationClipSnapshot {
 	curveKeyable: any;
+	value: any;
+	curveNames: string[];
+	time: number;
 }
 
 declare class AnimationClip extends Playable {
 	duration: number;
 	animCurves: any;
 	session: AnimationSession;
+	animCurvesMap: any;
 }
 
+// AnimationEvent is a CSS class, so I added an underscore
 declare interface AnimationEvent_ {
 
 }
@@ -35,6 +47,7 @@ declare class AnimationSession {
 	blendables: any;
 	_cacheBlendValues: any;
 	blendWeights: any;
+	animEvents: AnimationEvent_[];
 	_allocatePlayableCache(): any;
 }
 
@@ -45,7 +58,12 @@ declare interface AnimationComponent {
 }
 
 declare interface Playable {
+	animCurvesMap: any;
+	session: AnimationSession;
+	bySpeed: any;
+	loop: any;
 	getAnimTargets(): AnimationTargetsMap;
+	eval_cache(time: number, cacheKeyIdx: any, cacheValue: any): any;
 }
 
 declare interface AnimationTargetsMap {


### PR DESCRIPTION
Hey all, I added a bunch of type definitions via jsdoc style and tsconfig.json, but TypeScript is basically just used as a type checker for JavaScript (really nice support in vscode).

The better the types, the more errors can vscode show to the developer. Kinda looks like this:

![playcanvas_gltf_vscode](https://user-images.githubusercontent.com/5236548/51028074-bfdf4600-1592-11e9-8613-16bfad1b71a5.png)

Just by adding the types I figured out bugs / issues:

1) `AnimationEvent` is a stock class name for CSS animations
2) As in screenshot, the wrong comparison of `keyable1.type != keyable2` in two methods
3) `cloned.fadtTime = this.fadeTime;` as in the other issue

A bunch of types are still missing (basically all `idk` and `any` can/should be specified more precise). This jsdoc/TypeScript approach also allows IntelliSense/autocomplete for the developer.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
