### PR TITLE
TargetPath string to enum

### DIFF
--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -126,7 +126,7 @@
                     curve = new AnimationCurve();
                     keyType = AnimationKeyableType.NUM;
                     curve.keyableType = keyType;
-                    curve.addTarget("model", path, i);
+                    curve.addTarget("model", TargetPath.Weights, i);
                     if (sampler.interpolation === "CUBIC")
                         curve.type = AnimationCurveType.CUBIC;
                     else if (sampler.interpolation === "STEP")
@@ -146,15 +146,15 @@
                 switch (path) {
                     case "translation":
                         keyType = AnimationKeyableType.VEC;
-                        targetPath = "localPosition";
+                        targetPath = TargetPath.LocalPosition;
                         break;
                     case "scale":
                         keyType = AnimationKeyableType.VEC;
-                        targetPath = "localScale";
+                        targetPath = TargetPath.LocalScale;
                         break;
                     case "rotation":
                         keyType = AnimationKeyableType.QUAT;
-                        targetPath = "localRotation";
+                        targetPath = TargetPath.LocalRotation;
                         break;
                 }
                 curve = new AnimationCurve();

--- a/types/playcanvas-gltf/index.d.ts
+++ b/types/playcanvas-gltf/index.d.ts
@@ -25,7 +25,7 @@ declare interface AnimationEventCallback {
 declare interface AnimationTarget {
     vScale?: pc.Vec3 | number[];
     targetNode: pc.GraphNode;
-    targetPath: string;
+    targetPath: TargetPath;
     targetProp: string;
 }
 

--- a/viewer/src/utils.js
+++ b/viewer/src/utils.js
@@ -100,9 +100,10 @@ function clone_gltf(entity) {
     // 3) assign new AnimationComponent
     entity_clone.animComponent = new AnimationComponent();
     // 4) clone animation clips
-    var animationClips = [];
-    for (var i=0; i<entity.animComponent.animClips.length; i++)
-        animationClips.push( entity.animComponent.animClips[i].clone() );
+    var numClips = entity.animComponent.animClips.length;
+    var animationClips = Array(numClips);
+    for (var i=0; i<numClips; i++)
+        animationClips[i] = entity.animComponent.animClips[i].clone();
     // 5) assign entity_clone to each clip->curve->target
     for (var i = 0; i < animationClips.length; i++) {
         var clip = animationClips[i];
@@ -122,29 +123,22 @@ function clone_gltf(entity) {
 }
 
 /**
- * @param {pc.Entity} entity
- */
-
-function gltf_play_first_clip(entity) {
-    if (!entity.animComponent)
-        return;
-    entity.animComponent.curClip = entity.animComponent.animClips[0].name;
-    entity.animComponent.animClips[0].loop = true;
-    entity.animComponent.animClips[0].play();
-}
-
-/**
  * @param {pc.Entity} gltf
  * @param {number} x
  * @param {number} y
  * @param {number} z
  */
 
-function gltf_clone_setpos_playfirstclip(gltf, x, y, z) {
+function gltf_clone_setpos_playclip(gltf, x, y, z) {
     var cloned = clone_gltf(gltf);
     cloned.enabled = true;
     cloned.setLocalPosition(x, y, z);
-    gltf_play_first_clip(cloned);
+    if (gltf.animComponent) {
+        var activeClipName = gltf.animComponent.curClip;
+        var activeClip = cloned.animComponent.animClipsMap[activeClipName];
+        activeClip.loop = true;
+        activeClip.play();
+    }
     return cloned;
 }
 
@@ -171,7 +165,7 @@ function spawn8x8() {
     }
     for (var i=1; i<=8; i++) {
         for (var j=1; j<=8; j++) {
-            var clone = gltf_clone_setpos_playfirstclip(entity, i * padding_x, 0, j * padding_z * -1);
+            var clone = gltf_clone_setpos_playclip(entity, i * padding_x, 0, j * padding_z * -1);
             clones.push(clone);
         }
     }

--- a/viewer/src/utils.js
+++ b/viewer/src/utils.js
@@ -143,7 +143,7 @@ function gltf_clone_setpos_playclip(gltf, x, y, z) {
 }
 
 clones = [];
-
+clonesNextHeight = 0;
 /**
  * @summary
  * clones the current viewer.gltf 64 times
@@ -156,23 +156,32 @@ function spawn8x8() {
         return;
     var entity = viewer.gltf;
     var padding_x = 0;
+    var padding_y = 0;
     var padding_z = 0;
     for (var i=0; i<entity.model.meshInstances.length; i++) {
         var aabb = entity.model.meshInstances[i].aabb;
         //console.log(aabb.halfExtents);
         padding_x = Math.max(padding_x, aabb.halfExtents.x * 2);
+        padding_y = Math.max(padding_y, aabb.halfExtents.y * 2);
         padding_z = Math.max(padding_z, aabb.halfExtents.z * 2);
     }
     for (var i=1; i<=8; i++) {
         for (var j=1; j<=8; j++) {
-            var clone = gltf_clone_setpos_playclip(entity, i * padding_x, 0, j * padding_z * -1);
+            var clone = gltf_clone_setpos_playclip(
+                entity,
+                i * padding_x,     // x
+                clonesNextHeight,  // y
+                j * padding_z * -1 // z
+            );
             clones.push(clone);
         }
     }
-    
+    clonesNextHeight += padding_y;
     // add all clones to scene
     for (var i=0; i<clones.length; i++) {
         var clone = clones[i];
+        if (clone.parent) // only add non-parented clones to scene
+            continue;
         viewer.app.root.addChild(clone);
     }
 }


### PR DESCRIPTION
This PR replaces all the targetpath strings with enums, which makes `if`/`switch` comparisons faster and should also use less memory.

Somewhat more refactored:

 - `AnimationTarget.prototype.blendToTarget`
 - `AnimationTarget.prototype.updateToTarget`

Both methods are kinda samish, they use now the least amount of comparisons possible via one `switch` for every case.

And each targetpath case is expatiated, which reduces the amount of string lookups like `this.targetNode[this.targetPath]`.

That also makes it easier to profile the individual cases (e.g. set breakpoint on one case only) and shows precise timing data for each case:

![image](https://user-images.githubusercontent.com/5236548/53624575-0a7b5700-3c01-11e9-9779-56c76065cfb2.png)

And as comparison, the old code:

![image](https://user-images.githubusercontent.com/5236548/53624610-2a127f80-3c01-11e9-92a8-5338e87b83bb.png)

Last, but not least: a bit more type safe :^)

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
