### PR TITLE
Convert viewer.anim_slider.value string value to number

### DIFF
--- a/editor/src/viewer.js
+++ b/editor/src/viewer.js
@@ -295,7 +295,7 @@ Viewer.prototype = {
         
         this.anim_slider = document.getElementById("anim_slider");
         this.anim_slider.oninput = function(e) {
-            var curTime = this.anim_slider.value;
+            var curTime = Number(this.anim_slider.value);
             this.pauseAnimationsAndSeekToTime(curTime);
         }.bind(this);
         

--- a/viewer/src/viewer.js
+++ b/viewer/src/viewer.js
@@ -299,7 +299,7 @@ Viewer.prototype = {
         
         this.anim_slider = document.getElementById("anim_slider");
         this.anim_slider.oninput = function(e) {
-            var curTime = this.anim_slider.value;
+            var curTime = Number(this.anim_slider.value);
             this.pauseAnimationsAndSeekToTime(curTime);
         }.bind(this);
         


### PR DESCRIPTION
Quite surprisingly that `"0.5" < 0.6` etc. is working, so this never caused more bugs.

But this caused bugs for some of my testing when the slider is pushed to either "0" or "1", then something in the float/string logic didn't work anymore.

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
