### PR TITLE
 frame skipping.

### DIFF
--- a/src/playcanvas-anim.js
+++ b/src/playcanvas-anim.js
@@ -2472,6 +2472,7 @@ AnimationSession.prototype.play = function (playable, animTargets) {
 
     var app = pc.Application.getApplication();
     app.on('update', this.onTimer);
+    this.showAt(this.curTime, this.fadeDir, this.fadeBegTime, this.fadeEndTime, this.fadeTime);
     return this;
 };
 


### PR DESCRIPTION
Calling play immediately after an action is played will result in frame skipping.
