### PR TITLE
Fix incorrect handling of unlit materials

### DIFF
--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -385,6 +385,24 @@
 
         if (data.hasOwnProperty('extensions') && data.extensions.hasOwnProperty('KHR_materials_unlit')) {
             material.useLighting = false;
+
+            // Make sure diffuse is not actually combined with any form of lighting
+            material.chunks.combineDiffusePS = [
+                "vec3 combineColor() {",
+                "    return dAlbedo;",
+                "}",
+            ].join('\n') + "\n";
+
+            material.useSpecular = false;
+
+            // NOTE: Although useSpecular is a documented property of pc.StandardMaterial,
+            // it doesn't seem to be used. Hence why below chunks need to be changed as well: 
+            material.chunks.combineDiffuseSpecularPS = 
+                material.chunks.combineDiffuseSpecularOldPS = 
+                material.chunks.combineDiffuseSpecularNoReflPS = 
+                material.chunks.combineDiffuseSpecularNoConservePS = 
+                material.chunks.combineDiffuseSpecularNoReflSeparateAmbientPS =
+                material.chunks.combineDiffusePS;
         }
 
         var color, texture;

--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -382,29 +382,7 @@
         if (data.hasOwnProperty('name')) {
             material.name = data.name;
         }
-
-        if (data.hasOwnProperty('extensions') && data.extensions.hasOwnProperty('KHR_materials_unlit')) {
-            material.useLighting = false;
-
-            // Make sure diffuse is not actually combined with any form of lighting
-            material.chunks.combineDiffusePS = [
-                "vec3 combineColor() {",
-                "    return dAlbedo;",
-                "}",
-            ].join('\n') + "\n";
-
-            material.useSpecular = false;
-
-            // NOTE: Although useSpecular is a documented property of pc.StandardMaterial,
-            // it doesn't seem to be used. Hence why below chunks need to be changed as well: 
-            material.chunks.combineDiffuseSpecularPS = 
-                material.chunks.combineDiffuseSpecularOldPS = 
-                material.chunks.combineDiffuseSpecularNoReflPS = 
-                material.chunks.combineDiffuseSpecularNoConservePS = 
-                material.chunks.combineDiffuseSpecularNoReflSeparateAmbientPS =
-                material.chunks.combineDiffusePS;
-        }
-
+        
         var color, texture;
         if (data.hasOwnProperty('extensions') && data.extensions.hasOwnProperty('KHR_materials_pbrSpecularGlossiness')) {
             var specData = data.extensions.KHR_materials_pbrSpecularGlossiness;
@@ -551,6 +529,29 @@
             }
 
             material.chunks.glossPS = glossChunk;
+        }
+
+        if (data.hasOwnProperty('extensions') && data.extensions.hasOwnProperty('KHR_materials_unlit')) {
+            material.useLighting = false;
+
+            // Make sure diffuse is not actually combined with any form of lighting
+            material.chunks.combineDiffusePS = [
+                "vec3 combineColor() {",
+                "    return dAlbedo;",
+                "}",
+            ].join('\n') + "\n";
+
+            material.useMetalness = false; // Make sure shader chunk metalnessPS doesn't change dAlbedo
+            material.useSpecular = false;
+
+            // NOTE: Although useSpecular is a documented property of pc.StandardMaterial,
+            // it doesn't seem to be used. Hence why below chunks need to be changed as well: 
+            material.chunks.combineDiffuseSpecularPS = 
+                material.chunks.combineDiffuseSpecularOldPS = 
+                material.chunks.combineDiffuseSpecularNoReflPS = 
+                material.chunks.combineDiffuseSpecularNoConservePS = 
+                material.chunks.combineDiffuseSpecularNoReflSeparateAmbientPS =
+                material.chunks.combineDiffusePS;
         }
 
         if (data.hasOwnProperty('normalTexture')) {


### PR DESCRIPTION
Fixes #77

PR does two things, if material has extension `KHR_materials_unlit`:

1. Makes sure `material.chunks.combineDiffusePS` only uses diffuse color.
2. Disables metalness to make sure `material.chunks.metalnessPS` doesn't change diffuse color.

---

With PR:
![playcanvas-gltf-viewer-unlittest-withpr](https://user-images.githubusercontent.com/255073/61254012-69320f00-a763-11e9-9148-9c40319042d8.jpg)


Without PR:
![playcanvas-gltf-viewer-unlittest](https://user-images.githubusercontent.com/255073/61254009-66cfb500-a763-11e9-8c2c-6ea82278c9d8.jpg)


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
