### PR TITLE
Fix support for rendering points

### DIFF
--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -630,6 +630,9 @@
             resources.processMaterialExtras(material, data.extras);
         }
 
+        // gl_PointSize is required for rendering points but ignored for lines and triangles.
+        material.chunks.startVS = pc.shaderChunks.startVS + "    gl_PointSize = 1.0;\n";
+
         material.update();
 
         return material;


### PR DESCRIPTION
Fixes #79

PR does only one thing:

- Adds `gl_PointSize = 1.0;` at the start of the vertex shader, which is required for points to be displayed. Other primitives (lines and triangles) will ignore this value in the shader.

NOTE: the point size is set to `1.0` per specification: https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#point-and-line-materials

---

With PR:
![playcanvas-gltf-pointtest-withpr](https://user-images.githubusercontent.com/255073/61254899-98964b00-a766-11e9-93ef-05d0523fd1e2.png)


Without PR:
![playcanvas-gltf-pointtest-withoutpr](https://user-images.githubusercontent.com/255073/61254907-9c29d200-a766-11e9-8eaa-cbe62fe31e92.png)


I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
