### PR TITLE
[Fix] changes to pc.Morph API compatibility

### DIFF
--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -1062,10 +1062,10 @@ Object.assign(window, function () {
                         options.deltaTangents = getAccessorData(gltf, accessor, resources.buffers);
                     }
 
-                    targets.push(new pc.MorphTarget(resources.device, options));
+                    targets.push(new pc.MorphTarget(options));
                 });
 
-                mesh.morph = new pc.Morph(targets);
+                mesh.morph = new pc.Morph(resources.device, targets);
             }
 
             meshes.push(mesh);


### PR DESCRIPTION
- needs to be merged in after https://github.com/playcanvas/engine/pull/2123 is released (most likely in 1.29.0)
- not that this makes it compatible with engine's API but works without it, engine's API accept both formats.