### PR TITLE
Clear browser storage of texture blob

### DIFF
--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -311,7 +311,6 @@ Object.assign(window, function () {
                 success();
             }
 
-            // Check if it's a blob DOMString so we can free it
             if (loadedBlob) {
                 URL.revokeObjectURL(image.src);
             }
@@ -319,6 +318,10 @@ Object.assign(window, function () {
 
         var onError = function () {
             console.error('Could not load image from url ' + image.src);
+
+            if (loadedBlob) {
+                URL.revokeObjectURL(image.src);
+            }
         };
 
         image.addEventListener('load', onLoad, false);

--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -309,6 +309,11 @@ Object.assign(window, function () {
             if (resources.imagesLoaded === gltf.images.length) {
                 success();
             }
+
+            // Check if it's a blob DOMString so we can free it
+            if (image.src.startsWith('blob')) {
+                URL.revokeObjectURL(image.src);
+            }
         };
 
         var onError = function () {

--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -277,6 +277,7 @@ Object.assign(window, function () {
 
     function translateImage(data, resources, success) {
         var image = new Image();
+        var loadedBlob = false;
 
         var onLoad = function () {
             image.removeEventListener('load', onLoad, false);
@@ -311,7 +312,7 @@ Object.assign(window, function () {
             }
 
             // Check if it's a blob DOMString so we can free it
-            if (image.src.startsWith('blob')) {
+            if (loadedBlob) {
                 URL.revokeObjectURL(image.src);
             }
         };
@@ -346,6 +347,8 @@ Object.assign(window, function () {
             var imageBuffer = arrayBuffer.slice(byteOffset, byteOffset + bufferView.byteLength);
             var blob = new Blob([imageBuffer], { type: data.mimeType });
             image.src = URL.createObjectURL(blob);
+
+            loadedBlob = true;
         }
 
         return image;


### PR DESCRIPTION
Fixes a browser crash on low memory devices when continuously loading and unloading textured GLBs

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
