### PR TITLE
Three Morph fixes (assign target names, default morph weight and pc.Morph call)

### DIFF
--- a/src/playcanvas-gltf.js
+++ b/src/playcanvas-gltf.js
@@ -1058,7 +1058,7 @@ Object.assign(window, function () {
             if (primitive.hasOwnProperty('targets')) {
                 var targets = [];
 
-                primitive.targets.forEach(function (target) {
+                primitive.targets.forEach(function (target, targetIndex) {
                     var options = {};
                     if (target.hasOwnProperty('POSITION')) {
                         accessor = gltf.accessors[target.POSITION];
@@ -1072,11 +1072,19 @@ Object.assign(window, function () {
                         accessor = gltf.accessors[target.TANGENT];
                         options.deltaTangents = getAccessorData(gltf, accessor, resources.buffers);
                     }
+                    if (data.hasOwnProperty('extras') && data.extras.hasOwnProperty('targetNames') && data.extras.targetNames[targetIndex]) {
+                        options.name = data.extras.targetNames[targetIndex];
+                    } else {
+                        options.name = '' + targetIndex;
+                    }
+                    if (data.hasOwnProperty('weights') && data.weights[targetIndex]) {
+                        options.defaultWeight = data.weights[targetIndex];
+                    }
 
                     targets.push(new pc.MorphTarget(options));
                 });
 
-                mesh.morph = new pc.Morph(resources.device, targets);
+                mesh.morph = new pc.Morph(targets, resources.device);
             }
 
             meshes.push(mesh);


### PR DESCRIPTION
* Assign morph target name if available

Following the way explained here: https://github.com/KhronosGroup/glTF/issues/1036

* Assign defaultWeight if available:

Fixes #36 by simply using the code which was made for this in the engine (`MorphTargetOptions#defaultWeight`)

![image](https://user-images.githubusercontent.com/5236548/126617516-e376f5bb-856a-4ecc-8cdb-faea87254518.png)

(Thanks @MackeyK24 for the test model!)

* Fix pc.Morph targets, device order:

I don't know when this change was introduced, but in `playcanvas-stable.js` its like this:

![image](https://user-images.githubusercontent.com/5236548/126617362-0172bb15-d992-4cc6-b63e-808959c21b22.png)

Quick way to extract morph instances for testing:
```js
viewer.gltf.model.meshInstances.filter(x=>x.morphInstance).map(x=>x.morphInstance)
```

I confirm I have signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
